### PR TITLE
Fix notification url property on PayoutBatch

### DIFF
--- a/src/BitPaySDK/Model/Payout/PayoutBatch.php
+++ b/src/BitPaySDK/Model/Payout/PayoutBatch.php
@@ -190,6 +190,9 @@ class PayoutBatch
         $this->_notificationUrl = $notificationUrl;
     }
 
+    /**
+     * @deprecated Use setNotificationURL instead
+     */
     public function setRedirectURL(string $notificationUrl)
     {
         $this->setNotificationURL($notificationUrl);

--- a/src/BitPaySDK/Model/Payout/PayoutBatch.php
+++ b/src/BitPaySDK/Model/Payout/PayoutBatch.php
@@ -184,10 +184,15 @@ class PayoutBatch
     {
         return $this->_notificationUrl;
     }
+    
+    public function setNotificationURL(string $notificationUrl)
+    {
+        $this->_notificationUrl = $notificationUrl;
+    }
 
     public function setRedirectURL(string $notificationUrl)
     {
-        $this->_notificationUrl = $notificationUrl;
+        $this->setNotificationURL($notificationUrl);
     }
 
     public function getPricingMethod()
@@ -324,7 +329,7 @@ class PayoutBatch
             'instructions'      => $this->getInstructions(),
             'reference'         => $this->getReference(),
             'notificationEmail' => $this->getNotificationEmail(),
-            'notificationUrl'   => $this->getNotificationURL(),
+            'notificationURL'   => $this->getNotificationURL(),
             'pricingMethod'     => $this->getPricingMethod(),
             'id'                => $this->getId(),
             'account'           => $this->getAccount(),


### PR DESCRIPTION
- Add setter for `notificationUrl`, otherwise the mapper won't work correctly
- Fix typo on `notificationURL` array key