### PR TITLE
Move out logic from DTO

### DIFF
--- a/src/BitPaySDK/Model/Payout/PayoutBatch.php
+++ b/src/BitPaySDK/Model/Payout/PayoutBatch.php
@@ -41,6 +41,7 @@ class PayoutBatch
     protected $_btc;
     protected $_requestDate;
     protected $_dateExecuted;
+    protected $_currencyInfo;
 
     /**
      * Constructor, create an instruction-full request PayoutBatch object.
@@ -51,11 +52,12 @@ class PayoutBatch
      *                       UTC are guaranteed to be processed on the same day.
      * @param $instructions  array Payout instructions.
      */
-    public function __construct(string $currency = "USD", string $effectiveDate = null, array $instructions = null)
+    public function __construct(string $currency = "USD", string $effectiveDate = null, array $instructions = null, array $currencyInfo = [])
     {
         $this->_currency = $currency;
         $this->_effectiveDate = $effectiveDate;
         $this->_instructions = $instructions;
+        $this->_currencyInfo = $currencyInfo;
         $this->_computeAndSetAmount();
     }
 
@@ -64,8 +66,11 @@ class PayoutBatch
 
     private function _computeAndSetAmount()
     {
-        $currencyInfo = BitPaySDK\Client::getCurrencyInfo($this->_currency);
-        $precision = is_null($currencyInfo) ? 2 : $currencyInfo->precision;
+        /**
+        * Null Coalescing Operator 
+        * @doc https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.coalesce
+        */
+        $precision = $this->_currencyInfo[$this->_currency]['precision'] ?? 2;
 
         $amount = 0.0;
         if ($this->_instructions) {
@@ -325,6 +330,16 @@ class PayoutBatch
     public function setDateExecuted(string $dateExecuted)
     {
         $this->_dateExecuted = $dateExecuted;
+    }
+    
+    public function setCurrencyInfo(array $currencyInfo)
+    {
+        $this->_currnecyinfo = $currencyInfo;
+    }
+    
+    public function getCurrencyInfo()
+    {
+        return $this->_currencyInfo;
     }
 
     public function toArray()


### PR DESCRIPTION
Moved out logic from DTO object, ideally DTO should always contain only data without any logic or interaction with other services
List of currencies need to be injected in construct or in setter