### PR TITLE
Add the ability to specify a proxy url to send requests through to bitpay

### DIFF
--- a/examples/BitPay.config.yml
+++ b/examples/BitPay.config.yml
@@ -12,3 +12,4 @@ BitPayConfiguration:
       ApiTokens:
         merchant: null
         payroll: null
+      Proxy: null

--- a/src/BitPaySDK/Util/RESTcli/RESTcli.php
+++ b/src/BitPaySDK/Util/RESTcli/RESTcli.php
@@ -32,10 +32,16 @@ class RESTcli
      */
     protected $_identity;
 
-    public function __construct(string $environment, PrivateKey $ecKey)
+    /**
+     * @var string
+     */
+    protected $_proxy;
+
+    public function __construct(string $environment, PrivateKey $ecKey, ?string $proxy = null)
     {
         $this->_ecKey = $ecKey;
         $this->_baseUrl = $environment == Env::Test ? Env::TestUrl : Env::ProdUrl;
+        $this->_proxy = $proxy !== null ? trim($proxy) : '';
         $this->init();
     }
 
@@ -43,18 +49,23 @@ class RESTcli
     {
         try {
             $this->_identity = $this->_ecKey->getPublicKey()->__toString();
-            $this->_client = new GuzzleHttpClient(
-                [
-                    'base_url' => $this->_baseUrl,
-                    'defaults' => [
-                        'headers' => [
-                            'x-accept-version'           => Env::BitpayApiVersion,
-                            'x-bitpay-plugin-info'       => Env::BitpayPluginInfo,
-                            'x-bitpay-api-frame'         => Env::BitpayApiFrame,
-                            'x-bitpay-api-frame-version' => Env::BitpayApiFrameVersion,
-                        ],
+            $config = [
+                'base_url' => $this->_baseUrl,
+                'defaults' => [
+                    'headers' => [
+                        'x-accept-version'           => Env::BitpayApiVersion,
+                        'x-bitpay-plugin-info'       => Env::BitpayPluginInfo,
+                        'x-bitpay-api-frame'         => Env::BitpayApiFrame,
+                        'x-bitpay-api-frame-version' => Env::BitpayApiFrameVersion,
                     ],
-                ]);
+                ],
+            ];
+
+            if ($this->_proxy !== '') {
+                $config['proxy'] = $this->_proxy;
+            }
+
+            $this->_client = new GuzzleHttpClient($config);
         } catch (Exception $e) {
             throw new BitPayException("RESTcli init failed : ".$e->getMessage());
         }

--- a/src/BitPaySDK/Util/RESTcli/RESTcli.php
+++ b/src/BitPaySDK/Util/RESTcli/RESTcli.php
@@ -229,6 +229,9 @@ class RESTcli
 
         try {
             $body = json_decode($response->getBody()->getContents(), true);
+            if ($this->_proxy !== '' && !is_array($body)) {
+                throw new BitPayException("Please check your proxy settings, HTTP Code:".$response->getStatusCode().", failed to decode json: ".json_last_error_msg());
+            }
             $error_message = false;
             $error_message = (!empty($body['error'])) ? $body['error'] : $error_message;
             $error_message = (!empty($body['errors'])) ? $body['errors'] : $error_message;


### PR DESCRIPTION
It would be a nice addition to add the ability to support proxy urls via the bitpay wrapper here since guzzle does support the ability to proxy requests through.

Few key reasons on why I would like this to be merged in.

In some instances companies tend to have a heavy firewall, and will result into having to proxy 3rd party requests to a proxy server do to compliance reasons in us knowing where the traffic comes from.

bitpay.com has consistently changed the ips whether it is via cloudflare or not. We no longer can whitelist the ip address through to our firewall to allow outbound traffic to it.