### PR TITLE
SP-196 Add RefundWebhook and Image fields

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
 on:
+  pull_request:
+    branches:
+      - 'master'
   push:
     branches-ignore:
       - 'master'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  pull_request:
-    branches:
-      - 'master'
   push:
     branches-ignore:
       - 'master'

--- a/src/BitPaySDK/Model/Invoice/RefundWebhook.php
+++ b/src/BitPaySDK/Model/Invoice/RefundWebhook.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BitPaySDK\Model\Invoice;
 
 class RefundWebhook
@@ -20,117 +22,117 @@ class RefundWebhook
     {
     }
 
-    public function getId()
+    public function getId(): string
     {
         return $this->_id;
     }
 
-    public function setId(string $id)
+    public function setId(string $id): void
     {
         $this->_id = $id;
     }
 
-    public function getInvoice()
+    public function getInvoice(): string
     {
         return $this->_invoice;
     }
 
-    public function setInvoice(string $invoice)
+    public function setInvoice(string $invoice): void
     {
         $this->_invoice = $invoice;
     }
 
-    public function getSupportRequest()
+    public function getSupportRequest(): string
     {
         return $this->_supportRequest;
     }
 
-    public function setSupportRequest(string $supportRequest)
+    public function setSupportRequest(string $supportRequest): void
     {
         $this->_supportRequest = $supportRequest;
     }
 
-    public function getStatus()
+    public function getStatus(): string
     {
         return $this->_status;
     }
 
-    public function setStatus(string $status)
+    public function setStatus(string $status): void
     {
         $this->_status = $status;
     }
 
-    public function getAmount()
+    public function getAmount(): float
     {
         return $this->_amount;
     }
 
-    public function setAmount(float $amount)
+    public function setAmount(float $amount): void
     {
         $this->_amount = $amount;
     }
 
-    public function getCurrency()
+    public function getCurrency(): string
     {
         return $this->_currency;
     }
 
-    public function setCurrency(string $currency)
+    public function setCurrency(string $currency): void
     {
         $this->_currency = $currency;
     }
 
-    public function getLastRefundNotification()
+    public function getLastRefundNotification(): string
     {
         return $this->_lastRefundNotification;
     }
 
-    public function setLastRefundNotification(string $lastRefundNotification)
+    public function setLastRefundNotification(string $lastRefundNotification): void
     {
         $this->_lastRefundNotification = $lastRefundNotification;
     }
 
-    public function getRefundFee()
+    public function getRefundFee(): float
     {
         return $this->_refundFee;
     }
 
-    public function setRefundFee(float $refundFee)
+    public function setRefundFee(float $refundFee): void
     {
         $this->_refundFee = $refundFee;
     }
 
-    public function getImmediate()
+    public function getImmediate(): bool
     {
         return $this->_immediate;
     }
 
-    public function setImmediate(bool $immediate)
+    public function setImmediate(bool $immediate): void
     {
         $this->_immediate = $immediate;
     }
 
-    public function getBuyerPaysRefundFee()
+    public function getBuyerPaysRefundFee(): bool
     {
         return $this->_buyerPaysRefundFee;
     }
 
-    public function setBuyerPaysRefundFee(bool $buyerPaysRefundFee)
+    public function setBuyerPaysRefundFee(bool $buyerPaysRefundFee): void
     {
         $this->_buyerPaysRefundFee = $buyerPaysRefundFee;
     }
 
-    public function getRequestDate()
+    public function getRequestDate(): string
     {
         return $this->_requestDate;
     }
 
-    public function setRequestDate(string $requestDate)
+    public function setRequestDate(string $requestDate): void
     {
         $this->_requestDate = $requestDate;
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         $elements = [
             'id'                     => $this->getId(),

--- a/src/BitPaySDK/Model/Invoice/RefundWebhook.php
+++ b/src/BitPaySDK/Model/Invoice/RefundWebhook.php
@@ -16,7 +16,8 @@ class RefundWebhook
     protected $_buyerPaysRefundFee;
     protected $_requestDate;
 
-    public function __construct() {
+    public function __construct()
+    {
     }
 
     public function getId()

--- a/src/BitPaySDK/Model/Invoice/RefundWebhook.php
+++ b/src/BitPaySDK/Model/Invoice/RefundWebhook.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace BitPaySDK\Model\Invoice;
+
+class RefundWebhook
+{
+    protected $_id;
+    protected $_invoice;
+    protected $_supportRequest;
+    protected $_status;
+    protected $_amount;
+    protected $_currency;
+    protected $_lastRefundNotification;
+    protected $_refundFee;
+    protected $_immediate;
+    protected $_buyerPaysRefundFee;
+    protected $_requestDate;
+
+    public function __construct() {
+    }
+
+    public function getId()
+    {
+        return $this->_id;
+    }
+
+    public function setId(string $id)
+    {
+        $this->_id = $id;
+    }
+
+    public function getInvoice()
+    {
+        return $this->_invoice;
+    }
+
+    public function setInvoice(string $invoice)
+    {
+        $this->_invoice = $invoice;
+    }
+
+    public function getSupportRequest()
+    {
+        return $this->_supportRequest;
+    }
+
+    public function setSupportRequest(string $supportRequest)
+    {
+        $this->_supportRequest = $supportRequest;
+    }
+
+    public function getStatus()
+    {
+        return $this->_status;
+    }
+
+    public function setStatus(string $status)
+    {
+        $this->_status = $status;
+    }
+
+    public function getAmount()
+    {
+        return $this->_amount;
+    }
+
+    public function setAmount(float $amount)
+    {
+        $this->_amount = $amount;
+    }
+
+    public function getCurrency()
+    {
+        return $this->_currency;
+    }
+
+    public function setCurrency(string $currency)
+    {
+        $this->_currency = $currency;
+    }
+
+    public function getLastRefundNotification()
+    {
+        return $this->_lastRefundNotification;
+    }
+
+    public function setLastRefundNotification(string $lastRefundNotification)
+    {
+        $this->_lastRefundNotification = $lastRefundNotification;
+    }
+
+    public function getRefundFee()
+    {
+        return $this->_refundFee;
+    }
+
+    public function setRefundFee(float $refundFee)
+    {
+        $this->_refundFee = $refundFee;
+    }
+
+    public function getImmediate()
+    {
+        return $this->_immediate;
+    }
+
+    public function setImmediate(bool $immediate)
+    {
+        $this->_immediate = $immediate;
+    }
+
+    public function getBuyerPaysRefundFee()
+    {
+        return $this->_buyerPaysRefundFee;
+    }
+
+    public function setBuyerPaysRefundFee(bool $buyerPaysRefundFee)
+    {
+        $this->_buyerPaysRefundFee = $buyerPaysRefundFee;
+    }
+
+    public function getRequestDate()
+    {
+        return $this->_requestDate;
+    }
+
+    public function setRequestDate(string $requestDate)
+    {
+        $this->_requestDate = $requestDate;
+    }
+
+    public function toArray()
+    {
+        $elements = [
+            'id'                     => $this->getId(),
+            'invoice'                => $this->getInvoice(),
+            'supportRequest'         => $this->getSupportRequest(),
+            'status'                 => $this->getStatus(),
+            'amount'                 => $this->getAmount(),
+            'currency'               => $this->getCurrency(),
+            'lastRefundNotification' => $this->getLastRefundNotification(),
+            'refundFee'              => $this->getRefundFee(),
+            'immediate'              => $this->getImmediate(),
+            'buyerPaysRefundFee'     => $this->getBuyerPaysRefundFee(),
+            'requestDate'            => $this->getRequestDate()
+        ];
+
+        return $elements;
+    }
+}

--- a/src/BitPaySDK/Model/Wallet/Currencies.php
+++ b/src/BitPaySDK/Model/Wallet/Currencies.php
@@ -7,6 +7,7 @@ class Currencies
     protected $_code;
     protected $_p2p;
     protected $_dappBrowser;
+    protected $_image;
     protected $_payPro;
     protected $_qr;
     protected $_withdrawalFee;
@@ -14,7 +15,7 @@ class Currencies
 
     public function __construct()
     {
-        $this->_currencies = new CurrencyQr();
+        // $this->_currencies = new CurrencyQr();
     }
 
     public function getCode()
@@ -45,6 +46,16 @@ class Currencies
     public function setDappBrowser(bool $dappBrowser)
     {
         $this->_dappBrowser = $dappBrowser;
+    }
+
+    public function getImage()
+    {
+        return $this->_image;
+    }
+
+    public function setImage(string $image)
+    {
+        $this->_image = $image;
     }
 
     public function getPayPro()
@@ -93,6 +104,7 @@ class Currencies
             'code'            => $this->getCode(),
             'p2p'             => $this->getP2p(),
             'dappBrowser'     => $this->getDappBrowser(),
+            'image'           => $this->getImage(),
             'paypro'          => $this->getPayPro(),
             'qr'              => $this->getQr()->toArray(),
             'withdrawalFee'   => $this->getWithdrawalFee(),

--- a/src/BitPaySDK/Model/Wallet/Currencies.php
+++ b/src/BitPaySDK/Model/Wallet/Currencies.php
@@ -15,7 +15,7 @@ class Currencies
 
     public function __construct()
     {
-        // $this->_currencies = new CurrencyQr();
+        $this->_currencies = new CurrencyQr();
     }
 
     public function getCode()

--- a/src/BitPaySDK/Model/Wallet/Wallet.php
+++ b/src/BitPaySDK/Model/Wallet/Wallet.php
@@ -13,6 +13,7 @@ class Wallet
     protected $_avatar;
     protected $_paypro;
     protected $_currencies;
+    protected $_image;
 
     /**
      * Constructor, create a minimal request Wallet object.
@@ -74,14 +75,25 @@ class Wallet
         $this->_currencies = $currencies;
     }
 
+    public function getImage()
+    {
+        return $this->_image;
+    }
+
+    public function setImage(string $image)
+    {
+        $this->_image = $image;
+    }
+
     public function toArray()
     {
         $elements = [
-            'key'          => $this->getKey(),
-            'displayName'  => $this->getDisplayName(),
-            'avatar'       => $this->getAvatar(),
-            'paypro'       => $this->getPayPro(),
-            'currencies'   => $this->getCurrencies()->toArray()
+            'key'         => $this->getKey(),
+            'displayName' => $this->getDisplayName(),
+            'avatar'      => $this->getAvatar(),
+            'paypro'      => $this->getPayPro(),
+            'currencies'  => $this->getCurrencies()->toArray(),
+            'image'       => $this->getImage()
         ];
 
         return $elements;

--- a/test/unit/BitPaySDK/Model/Invoice/RefundWebhookTest.php
+++ b/test/unit/BitPaySDK/Model/Invoice/RefundWebhookTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace BitPaySDK\Test;
+
+use BitPaySDK\Model\Invoice\RefundWebhook;
+use PHPUnit\Framework\TestCase;
+
+class RefundWebhookTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $refundWebhook = $this->createClassObject();
+    $this->assertInstanceOf(RefundWebhook::class, $refundWebhook);
+  }
+
+  public function testGetId()
+  {
+    $expectedId = 'GZBBLcsgQamua3PN8GX92s';
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setId($expectedId);
+    $this->assertEquals($expectedId, $refundWebhook->getId());
+  }
+
+  public function testGetInvoice()
+  {
+    $expectedInvoice = 'Wp9cpGphCz7cSeFh6MSYpb';
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setInvoice($expectedInvoice);
+    $this->assertEquals($expectedInvoice, $refundWebhook->getInvoice());
+  }
+
+  public function testGetSupportRequest()
+  {
+    $expectedSupportRequest = 'XuuYtZfTw7G99Ws3z38kWZ';
+    
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setSupportRequest($expectedSupportRequest);
+    $this->assertEquals($expectedSupportRequest, $refundWebhook->getSupportRequest());
+  }
+
+  public function testGetStatus()
+  {
+    $expectedStatus = 'pending';
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setStatus($expectedStatus);
+    $this->assertEquals($expectedStatus, $refundWebhook->getStatus());
+  }
+
+  public function testGetAmount()
+  {
+    $expectedAmount = 6;
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setAmount($expectedAmount);
+    $this->assertEquals($expectedAmount, $refundWebhook->getAmount());
+  }
+
+  public function testGetCurrency()
+  {
+    $expectedCurrency = 'USD';
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setCurrency($expectedCurrency);
+    $this->assertEquals($expectedCurrency, $refundWebhook->getCurrency());
+  }
+
+  public function testGetLastRefundNotification()
+  {
+    $expectedLastRefundNotification = '2022-01-11T16:58:23.967Z';
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setLastRefundNotification($expectedLastRefundNotification);
+    $this->assertEquals($expectedLastRefundNotification, $refundWebhook->getLastRefundNotification());
+  }
+
+  public function testGetRefundFee()
+  {
+    $expectedRefundFee = 2.31;
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setRefundFee($expectedRefundFee);
+    $this->assertEquals($expectedRefundFee, $refundWebhook->getRefundFee());
+  }
+
+  public function testImmediate()
+  {
+    $expectedImmediate = false;
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setImmediate($expectedImmediate);
+    $this->assertEquals($expectedImmediate, $refundWebhook->getImmediate());
+  }
+
+  public function testGetBuyerPaysRefundFee()
+  {
+    $expectedBuyerPaysRefundFee = true;
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setBuyerPaysRefundFee($expectedBuyerPaysRefundFee);
+    $this->assertEquals($expectedBuyerPaysRefundFee, $refundWebhook->getBuyerPaysRefundFee());
+  }
+
+  public function testGetRequestDate()
+  {
+    $expectedRequestDate = '2022-01-11T16:58:23.000Z';
+
+    $refundWebhook = $this->createClassObject();
+    $refundWebhook->setRequestDate($expectedRequestDate);
+    $this->assertEquals($expectedRequestDate, $refundWebhook->getRequestDate());
+  }
+
+  public function testToArray()
+  {
+    $refundWebhook = $this->createClassObject();
+    $this->objectSetters($refundWebhook);
+
+    $refundWebhookArray = $refundWebhook->toArray();
+
+    $this->assertNotNull($refundWebhookArray);
+    $this->assertIsArray($refundWebhookArray);
+
+    $this->assertArrayHasKey('id', $refundWebhookArray);
+    $this->assertArrayHasKey('invoice', $refundWebhookArray);
+    $this->assertArrayHasKey('supportRequest', $refundWebhookArray);
+    $this->assertArrayHasKey('status', $refundWebhookArray);
+    $this->assertArrayHasKey('amount', $refundWebhookArray);
+    $this->assertArrayHasKey('currency', $refundWebhookArray);
+    $this->assertArrayHasKey('lastRefundNotification', $refundWebhookArray);
+    $this->assertArrayHasKey('refundFee', $refundWebhookArray);
+    $this->assertArrayHasKey('immediate', $refundWebhookArray);
+    $this->assertArrayHasKey('buyerPaysRefundFee', $refundWebhookArray);
+    $this->assertArrayHasKey('requestDate', $refundWebhookArray);
+
+    $this->assertEquals($refundWebhookArray['id'], 'GZBBLcsgQamua3PN8GX92s');
+    $this->assertEquals($refundWebhookArray['invoice'], 'Wp9cpGphCz7cSeFh6MSYpb');
+    $this->assertEquals($refundWebhookArray['supportRequest'], 'XuuYtZfTw7G99Ws3z38kWZ');
+    $this->assertEquals($refundWebhookArray['status'], 'pending');
+    $this->assertEquals($refundWebhookArray['amount'], 6);
+    $this->assertEquals($refundWebhookArray['currency'], 'USD');
+    $this->assertEquals($refundWebhookArray['lastRefundNotification'], '2022-01-11T16:58:23.967Z');
+    $this->assertEquals($refundWebhookArray['refundFee'], 2.31);
+    $this->assertEquals($refundWebhookArray['immediate'], false);
+    $this->assertEquals($refundWebhookArray['buyerPaysRefundFee'], true);
+    $this->assertEquals($refundWebhookArray['requestDate'], '2022-01-11T16:58:23.000Z');
+  }
+
+  private function createClassObject()
+  {
+    return new RefundWebhook();
+  }
+
+  private function objectSetters(RefundWebhook $refundWebhook): void
+  {
+    $refundWebhook->setId('GZBBLcsgQamua3PN8GX92s');
+    $refundWebhook->setInvoice('Wp9cpGphCz7cSeFh6MSYpb');
+    $refundWebhook->setSupportRequest('XuuYtZfTw7G99Ws3z38kWZ');
+    $refundWebhook->setStatus('pending');
+    $refundWebhook->setAmount(6);
+    $refundWebhook->setCurrency('USD');
+    $refundWebhook->setLastRefundNotification('2022-01-11T16:58:23.967Z');
+    $refundWebhook->setRefundFee(2.31);
+    $refundWebhook->setImmediate(false);
+    $refundWebhook->setBuyerPaysRefundFee(true);
+    $refundWebhook->setRequestDate('2022-01-11T16:58:23.000Z');
+  }
+}

--- a/test/unit/BitPaySDK/Model/Wallet/CurrenciesTest.php
+++ b/test/unit/BitPaySDK/Model/Wallet/CurrenciesTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace BitPaySDK\Test;
+
+use BitPaySDK\Model\Wallet\Currencies;
+use BitPaySDK\Model\Wallet\CurrencyQr;
+use PHPUnit\Framework\TestCase;
+
+class CurrenciesTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $currencies = $this->createClassObject();
+    $this->assertInstanceOf(Currencies::class, $currencies);
+  }
+
+  public function testGetCode()
+  {
+    $expectedCode = 'BTH';
+
+    $currencies = $this->createClassObject();
+    $currencies->setCode($expectedCode);
+    $this->assertEquals($expectedCode, $currencies->getCode());
+  }
+
+  public function testGetP2p()
+  {
+    $expectedP2p = true;
+
+    $currencies = $this->createClassObject();
+    $currencies->setP2p($expectedP2p);
+    $this->assertEquals($expectedP2p, $currencies->getP2p());
+  }
+
+  public function testGetDappBrowser()
+  {
+    $expectedDappBrowser = true;
+
+    $currencies = $this->createClassObject();
+    $currencies->setDappBrowser($expectedDappBrowser);
+    $this->assertEquals($expectedDappBrowser, $currencies->getDappBrowser());
+  }
+
+  public function testGetImage()
+  {
+    $expectedImage = 'https://bitpay.com/api/images/logo-6fa5404d.svg';
+
+    $currencies = $this->createClassObject();
+    $currencies->setImage($expectedImage, $currencies->getImage());
+    $this->assertEquals($expectedImage, $currencies->getImage());
+  }
+
+  public function testGetPayPro()
+  {
+    $expectedPayPro = true;
+
+    $currencies = $this->createClassObject();
+    $currencies->setPayPro($expectedPayPro);
+    $this->assertEquals($expectedPayPro, $currencies->getPayPro());
+  }
+
+  public function testGetQr()
+  {
+    $expectedCurrencyQr = new CurrencyQr;
+    $expectedCurrencyQr->setType = 'BIP21';
+    $expectedCurrencyQr->setCollapsed = false;
+
+    $currencies = $this->createClassObject();
+    $currencies->setQr($expectedCurrencyQr);
+
+    $this->assertEquals($expectedCurrencyQr, $currencies->getQr());
+  }
+
+  public function testGetWithdrawalFee()
+  {
+    $expectedWithdrawalFee = '1.23';
+
+    $currencies = $this->createClassObject();
+    $currencies->setWithdrawalFee($expectedWithdrawalFee);
+    $this->assertEquals($expectedWithdrawalFee, $currencies->getWithdrawalFee());
+  }
+
+  public function testGetWalletConnect()
+  {
+    $expectedWalletConnect = true;
+
+    $currencies = $this->createClassObject();
+    $currencies->setWalletConnect($expectedWalletConnect);
+    $this->assertEquals($expectedWalletConnect, $currencies->getWalletConnect());
+  }
+
+  public function testToArray()
+  {
+    $currencies = $this->createClassObject();
+    $this->objectSetters($currencies);
+    $currenciesArray = $currencies->toArray();
+
+    $this->assertNotNull($currenciesArray);
+    $this->assertIsArray($currenciesArray);
+
+    $this->assertArrayHasKey('code', $currenciesArray);
+    $this->assertArrayHasKey('p2p', $currenciesArray);
+    $this->assertArrayHasKey('dappBrowser', $currenciesArray);
+    $this->assertArrayHasKey('image', $currenciesArray);
+    $this->assertArrayHasKey('paypro', $currenciesArray);
+    $this->assertArrayHasKey('qr', $currenciesArray);
+    $this->assertArrayHasKey('withdrawalFee', $currenciesArray);
+    $this->assertArrayHasKey('walletConnect', $currenciesArray);
+
+    $this->assertEquals($currenciesArray['code'], 'BTH');
+    $this->assertEquals($currenciesArray['p2p'], true);
+    $this->assertEquals($currenciesArray['dappBrowser'], true);
+    $this->assertEquals($currenciesArray['image'], 'https://bitpay.com/api/images/logo-6fa5404d.svg');
+    $this->assertEquals($currenciesArray['paypro'], true);
+    $this->assertEquals($currenciesArray['qr']['type'], 'BIP21');
+    $this->assertEquals($currenciesArray['qr']['collapsed'], false);
+    $this->assertEquals($currenciesArray['withdrawalFee'], '1.23');
+    $this->assertEquals($currenciesArray['walletConnect'], true);
+  }
+
+  private function createClassObject()
+  {
+    return new Currencies();
+  }
+
+  private function objectSetters(Currencies $currencies): void
+  {
+    $currencyQr = new CurrencyQr;
+    $currencyQr->setType('BIP21');
+    $currencyQr->setCollapsed(false);
+
+    $currencies->setCode('BTH');
+    $currencies->setP2p(true);
+    $currencies->setDappBrowser(true);
+    $currencies->setImage('https://bitpay.com/api/images/logo-6fa5404d.svg');
+    $currencies->setPayPro(true);
+    $currencies->setQr($currencyQr);
+    $currencies->setWithdrawalFee('1.23');
+    $currencies->setWalletConnect(true);
+  }
+}

--- a/test/unit/BitPaySDK/Model/Wallet/CurrencyQrTest.php
+++ b/test/unit/BitPaySDK/Model/Wallet/CurrencyQrTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace BitPaySDK\Test;
+
+use BitPaySDK\Model\Wallet\CurrencyQr;
+use PHPUnit\Framework\TestCase;
+
+class CurrencyQrTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $currencyQr = $this->createClassObject();
+    $this->assertInstanceOf(CurrencyQr::class, $currencyQr);
+  }
+
+  public function testGetType()
+  {
+    $expectedType = 'BIP21';
+
+    $currencyQr = $this->createClassObject();
+    $currencyQr->setType($expectedType);
+    $this->assertEquals($expectedType, $currencyQr->getType());
+  }
+
+  public function testGetCollapsed()
+  {
+    $expectedCollapsed = false;
+
+    $currencyQr = $this->createClassObject();
+    $currencyQr->setCollapsed($expectedCollapsed);
+    $this->assertEquals($expectedCollapsed, $currencyQr->getCollapsed());
+  }
+
+  public function testToArray()
+  {
+    $currencyQr = $this->createClassObject();
+    $this->objectSetters($currencyQr);
+    $currencyQrArray = $currencyQr->toArray();
+
+    $this->assertNotNull($currencyQrArray);
+    $this->assertIsArray($currencyQrArray);
+
+    $this->assertArrayHasKey('type', $currencyQrArray);
+    $this->assertArrayHasKey('collapsed', $currencyQrArray);
+
+    $this->AssertEquals($currencyQrArray['type'], 'BIP21');
+    $this->AssertEquals($currencyQrArray['collapsed'], false);
+  }
+
+  private function createClassObject()
+  {
+    return new CurrencyQr();
+  }
+
+  private function objectSetters(CurrencyQr $currencyQr): void
+  {
+    $currencyQr->setType('BIP21');
+    $currencyQr->setCollapsed(false);
+  }
+}

--- a/test/unit/BitPaySDK/Model/Wallet/WalletTest.php
+++ b/test/unit/BitPaySDK/Model/Wallet/WalletTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace BitPaySDK\Test;
+
+use BitPaySDK\Model\Wallet\Currencies;
+use BitPaySDK\Model\Wallet\CurrencyQr;
+use BitPaySDK\Model\Wallet\Wallet;
+use PHPUnit\Framework\TestCase;
+
+class WalletTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $wallet = $this->createClassObject();
+    $this->assertInstanceOf(Wallet::class, $wallet);
+  }
+
+  public function testGetKey()
+  {
+    $expectedKey = 'abcd123';
+
+    $wallet = $this->createClassObject();
+    $wallet->setKey($expectedKey);
+    $this->assertEquals($expectedKey, $wallet->getKey());
+  }
+
+  public function testGetDisplayName()
+  {
+    $expectedDisplayName = 'My Wallet';
+
+    $wallet = $this->createClassObject();
+    $wallet->setDisplayName($expectedDisplayName);
+    $this->assertEquals($expectedDisplayName, $wallet->getDisplayName());
+  }
+
+  public function testGetAvatar()
+  {
+    $expectedAvatar = 'image.png';
+
+    $wallet = $this->createClassObject();
+    $wallet->setAvatar($expectedAvatar);
+    $this->assertEquals($expectedAvatar, $wallet->getAvatar());
+  }
+
+  public function testGetPayPro()
+  {
+    $expectedPayPro = true;
+    
+    $wallet = $this->createClassObject();
+    $wallet->setPayPro($expectedPayPro);
+    $this->assertEquals($expectedPayPro, $wallet->getPayPro());
+  }
+
+  public function testGetCurrencies()
+  {
+    $currencyQr = new CurrencyQr;
+    $currencyQr->setType('BIP21');
+    $currencyQr->setCollapsed(false);
+
+    $expectedCurrencies = new Currencies();
+    $expectedCurrencies->setCode('BTH');
+    $expectedCurrencies->setP2p(true);
+    $expectedCurrencies->setDappBrowser(true);
+    $expectedCurrencies->setImage('https://bitpay.com/api/images/logo-6fa5404d.svg');
+    $expectedCurrencies->setPayPro(true);
+    $expectedCurrencies->setQr($currencyQr);
+    $expectedCurrencies->setWithdrawalFee('1.23');
+    $expectedCurrencies->setWalletConnect(true);
+    
+    $wallet = $this->createClassObject();
+    $wallet->setCurrencies($expectedCurrencies);
+    $this->assertEquals($expectedCurrencies, $wallet->getCurrencies());
+  }
+
+  public function testGetImage()
+  {
+    $expectedImage = 'https://bitpay.com/api/images/logo-6fa5404d.svg';
+
+    $wallet = $this->createClassObject();
+    $wallet->setImage($expectedImage);
+    $this->assertEquals($expectedImage, $wallet->getImage());
+  }
+
+  public function testToArray()
+  {
+    $wallet = $this->createClassObject();
+    $this->objectSetters($wallet);
+    $walletArray = $wallet->toArray();
+
+    $this->assertNotNull($walletArray);
+    $this->assertIsArray($walletArray);
+
+    $this->assertArrayHasKey('key', $walletArray);
+    $this->assertArrayHasKey('displayName', $walletArray);
+    $this->assertArrayHasKey('avatar', $walletArray);
+    $this->assertArrayHasKey('paypro', $walletArray);
+    $this->assertArrayHasKey('currencies', $walletArray);
+    $this->assertArrayHasKey('image', $walletArray);
+
+    $this->assertEquals($walletArray['key'], 'abcd123');
+    $this->assertEquals($walletArray['displayName'], 'My Wallet');
+    $this->assertEquals($walletArray['avatar'], 'image.png');
+    $this->assertEquals($walletArray['paypro'], true);
+    $this->assertEquals($walletArray['currencies']['code'], 'BTH');
+    $this->assertEquals($walletArray['currencies']['p2p'], true);
+    $this->assertEquals($walletArray['currencies']['dappBrowser'], true);
+    $this->assertEquals($walletArray['currencies']['image'], 'https://bitpay.com/api/images/logo-6fa5404d.svg');
+    $this->assertEquals($walletArray['currencies']['paypro'], true);
+    $this->assertEquals($walletArray['currencies']['qr']['type'], 'BIP21');
+    $this->assertEquals($walletArray['currencies']['qr']['collapsed'], false);
+    $this->assertEquals($walletArray['currencies']['withdrawalFee'], '1.23');
+    $this->assertEquals($walletArray['currencies']['walletConnect'], true);
+    $this->assertEquals($walletArray['image'], 'https://bitpay.com/api/images/logo-6fa5404d.svg');
+  }
+
+  private function createClassObject()
+  {
+    return new Wallet();
+  }
+
+  private function objectSetters(Wallet $wallet): void
+  {
+    $currencyQr = new CurrencyQr;
+    $currencyQr->setType('BIP21');
+    $currencyQr->setCollapsed(false);
+
+    $currencies = new Currencies();
+    $currencies->setCode('BTH');
+    $currencies->setP2p(true);
+    $currencies->setDappBrowser(true);
+    $currencies->setImage('https://bitpay.com/api/images/logo-6fa5404d.svg');
+    $currencies->setPayPro(true);
+    $currencies->setQr($currencyQr);
+    $currencies->setWithdrawalFee('1.23');
+    $currencies->setWalletConnect(true);
+
+    $wallet->setKey('abcd123');
+    $wallet->setDisplayName('My Wallet');
+    $wallet->setAvatar('image.png');
+    $wallet->setPayPro(true);
+    $wallet->setCurrencies($currencies);
+    $wallet->setImage('https://bitpay.com/api/images/logo-6fa5404d.svg');
+  }
+}


### PR DESCRIPTION
# Overview

In an effort to have all SDKs in parity, this is a first step for the PHP SDK and implements the following:
* Adds `image` to Wallet
* Adds `image` to Wallet\Currencies
* Adds unit tests for Wallet
* Adds unit tests for Wallet\Currencies
* Adds unit tests for Wallet\CurrencyQr