### PR TITLE
SP-130 Exception Tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,11 +2,14 @@
 <!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" bootstrap="./vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true">
   <coverage>
+    <exclude>
+      <directory suffix=".php">./src/BitPaySDK/Util/JsonMapper</directory>
+    </exclude>
     <include>
-      <directory suffix=".php">src</directory>
+      <directory suffix=".php">./src</directory>
     </include>
     <report>
-      <html outputDirectory="test/unit/_html" />
+      <html outputDirectory="./test/unit/_html" />
     </report>
   </coverage>
   <testsuites>

--- a/src/BitPaySDK/Exceptions/BillCreationException.php
+++ b/src/BitPaySDK/Exceptions/BillCreationException.php
@@ -8,7 +8,6 @@ class BillCreationException extends BillException
 {
     private $bitPayMessage = "Failed to create bill";
     private $bitPayCode    = "BITPAY-BILL-CREATE";
-    protected $apiCode;
 
     /**
      * Construct the BillCreationException.
@@ -20,15 +19,6 @@ class BillCreationException extends BillException
     public function __construct($message = "", $code = 112, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/BillDeliveryException.php
+++ b/src/BitPaySDK/Exceptions/BillDeliveryException.php
@@ -8,7 +8,6 @@ class BillDeliveryException extends BillException
 {
     private $bitPayMessage = "Failed to deliver bill";
     private $bitPayCode    = "BITPAY-BILL-DELIVERY";
-    protected $apiCode;
 
     /**
      * Construct the BillDeliveryException.
@@ -20,15 +19,6 @@ class BillDeliveryException extends BillException
     public function __construct($message = "", $code = 115, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/BillException.php
+++ b/src/BitPaySDK/Exceptions/BillException.php
@@ -6,9 +6,8 @@ use Exception;
 
 class BillException extends BitPayException
 {
-    private $bitPayMessage = "An unexpected error occurred while trying to manage the bill";
-    private $bitPayCode    = "BITPAY-BILL-GENERIC";
-    protected $apiCode;
+    private   $bitPayMessage = "An unexpected error occurred while trying to manage the bill";
+    private   $bitPayCode    = "BITPAY-BILL-GENERIC";
 
     /**
      * Construct the BillException.
@@ -22,14 +21,6 @@ class BillException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/BillException.php
+++ b/src/BitPaySDK/Exceptions/BillException.php
@@ -6,8 +6,8 @@ use Exception;
 
 class BillException extends BitPayException
 {
-    private   $bitPayMessage = "An unexpected error occurred while trying to manage the bill";
-    private   $bitPayCode    = "BITPAY-BILL-GENERIC";
+    private $bitPayMessage = "An unexpected error occurred while trying to manage the bill";
+    private $bitPayCode    = "BITPAY-BILL-GENERIC";
 
     /**
      * Construct the BillException.

--- a/src/BitPaySDK/Exceptions/BillQueryException.php
+++ b/src/BitPaySDK/Exceptions/BillQueryException.php
@@ -8,7 +8,6 @@ class BillQueryException extends BillException
 {
     private $bitPayMessage = "Failed to retrieve bill";
     private $bitPayCode    = "BITPAY-BILL-GET";
-    protected $apiCode;
 
     /**
      * Construct the BillQueryException.
@@ -20,15 +19,6 @@ class BillQueryException extends BillException
     public function __construct($message = "", $code = 113, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/BillUpdateException.php
+++ b/src/BitPaySDK/Exceptions/BillUpdateException.php
@@ -8,7 +8,6 @@ class BillUpdateException extends BillException
 {
     private $bitPayMessage = "Failed to update bill";
     private $bitPayCode    = "BITPAY-BILL-UPDATE";
-    protected $apiCode;
 
     /**
      * Construct the BillUpdateException.
@@ -20,15 +19,6 @@ class BillUpdateException extends BillException
     public function __construct($message = "", $code = 114, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/CurrencyException.php
+++ b/src/BitPaySDK/Exceptions/CurrencyException.php
@@ -8,7 +8,6 @@ class CurrencyException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the currencies";
     private $bitPayCode    = "BITPAY-CURRENCY-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the CurrencyException.
@@ -22,14 +21,6 @@ class CurrencyException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/CurrencyQueryException.php
+++ b/src/BitPaySDK/Exceptions/CurrencyQueryException.php
@@ -8,7 +8,6 @@ class CurrencyQueryException extends CurrencyException
 {
     private $bitPayMessage = "Failed to retrieve currencies";
     private $bitPayCode    = "BITPAY-CURRENCY-GET";
-    protected $apiCode;
 
     /**
      * Construct the CurrencyQueryException.
@@ -21,14 +20,6 @@ class CurrencyQueryException extends CurrencyException
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/InvoiceCancellationException.php
+++ b/src/BitPaySDK/Exceptions/InvoiceCancellationException.php
@@ -2,11 +2,12 @@
 
 namespace BitPaySDK\Exceptions;
 
+use Exception;
+
 class InvoiceCancellationException extends InvoiceException
 {
     private $bitPayMessage = "Failed to cancel invoice object";
     private $bitPayCode    = "BITPAY-INVOICE-CANCEL";
-    protected $apiCode;
 
     /**
      * Construct the InvoiceCancellationException.
@@ -18,15 +19,6 @@ class InvoiceCancellationException extends InvoiceException
     public function __construct($message = "", $code = 105, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/InvoiceCreationException.php
+++ b/src/BitPaySDK/Exceptions/InvoiceCreationException.php
@@ -8,7 +8,6 @@ class InvoiceCreationException extends InvoiceException
 {
     private $bitPayMessage = "Failed to create invoice";
     private $bitPayCode    = "BITPAY-INVOICE-CREATE";
-    protected $apiCode;
 
     /**
      * Construct the InvoiceCreationException.
@@ -20,15 +19,6 @@ class InvoiceCreationException extends InvoiceException
     public function __construct($message = "", $code = 102, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/InvoiceException.php
+++ b/src/BitPaySDK/Exceptions/InvoiceException.php
@@ -8,7 +8,6 @@ class InvoiceException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the invoice";
     private $bitPayCode    = "BITPAY-INVOICE-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the InvoiceException.
@@ -22,14 +21,6 @@ class InvoiceException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/InvoicePaymentException.php
+++ b/src/BitPaySDK/Exceptions/InvoicePaymentException.php
@@ -8,7 +8,6 @@ class InvoicePaymentException extends InvoiceException
 {
     private $bitPayMessage = "Failed to pay invoice";
     private $bitPayCode    = "BITPAY-INVOICE-PAY-UPDATE";
-    protected $apiCode;
 
     /**
      * Construct the InvoicePaymentException.
@@ -21,14 +20,6 @@ class InvoicePaymentException extends InvoiceException
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/InvoiceQueryException.php
+++ b/src/BitPaySDK/Exceptions/InvoiceQueryException.php
@@ -20,15 +20,6 @@ class InvoiceQueryException extends InvoiceException
     public function __construct($message = "", $code = 103, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/InvoiceUpdateException.php
+++ b/src/BitPaySDK/Exceptions/InvoiceUpdateException.php
@@ -18,7 +18,6 @@ class InvoiceUpdateException extends InvoiceException
      */
     public function __construct($message = "", $code = 104, Exception $previous = null, $apiCode = "000000")
     {
-
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         parent::__construct($message, $code, $previous, $apiCode);
     }

--- a/src/BitPaySDK/Exceptions/InvoiceUpdateException.php
+++ b/src/BitPaySDK/Exceptions/InvoiceUpdateException.php
@@ -2,11 +2,12 @@
 
 namespace BitPaySDK\Exceptions;
 
+use Exception;
+
 class InvoiceUpdateException extends InvoiceException
 {
     private $bitPayMessage = "Failed to update invoice";
     private $bitPayCode    = "BITPAY-INVOICE-UPDATE";
-    protected $apiCode;
 
     /**
      * Construct the InvoiceUpdateException.
@@ -19,15 +20,6 @@ class InvoiceUpdateException extends InvoiceException
     {
 
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/LedgerException.php
+++ b/src/BitPaySDK/Exceptions/LedgerException.php
@@ -8,7 +8,6 @@ class LedgerException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the ledger";
     private $bitPayCode    = "BITPAY-LEDGER-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the LedgerException.
@@ -22,14 +21,6 @@ class LedgerException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/LedgerQueryException.php
+++ b/src/BitPaySDK/Exceptions/LedgerQueryException.php
@@ -8,7 +8,6 @@ class LedgerQueryException extends LedgerException
 {
     private $bitPayMessage = "Failed to retrieve ledger";
     private $bitPayCode    = "BITPAY-LEDGER-GET";
-    protected $apiCode;
 
     /**
      * Construct the LedgerQueryException.
@@ -21,14 +20,6 @@ class LedgerQueryException extends LedgerException
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutBatchCancellationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutBatchCancellationException.php
@@ -8,7 +8,6 @@ class PayoutBatchCancellationException extends PayoutBatchException
 {
     private $bitPayMessage = "Failed to cancel payout batch";
     private $bitPayCode    = "BITPAY-PAYOUT-BATCH-CANCEL";
-    protected $apiCode;
 
     /**
      * Construct the PayoutBatchCancellationException.
@@ -20,15 +19,6 @@ class PayoutBatchCancellationException extends PayoutBatchException
     public function __construct($message = "", $code = 204, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutBatchCreationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutBatchCreationException.php
@@ -8,7 +8,6 @@ class PayoutBatchCreationException extends PayoutBatchException
 {
     private $bitPayMessage = "Failed to create payout batch";
     private $bitPayCode    = "BITPAY-PAYOUT-BATCH-SUBMIT";
-    protected $apiCode;
 
     /**
      * Construct the PayoutBatchCreationException.
@@ -20,15 +19,6 @@ class PayoutBatchCreationException extends PayoutBatchException
     public function __construct($message = "", $code = 202, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutBatchException.php
+++ b/src/BitPaySDK/Exceptions/PayoutBatchException.php
@@ -8,7 +8,6 @@ class PayoutBatchException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the payout batch";
     private $bitPayCode    = "BITPAY-PAYOUT-BATCH-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the PayoutBatchException.
@@ -22,14 +21,6 @@ class PayoutBatchException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutBatchNotificationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutBatchNotificationException.php
@@ -8,7 +8,6 @@ class PayoutBatchNotificationException extends PayoutBatchException
 {
     private $bitPayMessage = "Failed to send payout batch notification";
     private $bitPayCode    = "BITPAY-PAYOUT-BATCH-NOTIFICATION";
-    protected $apiCode;
 
     /**
      * Construct the PayoutBatchNotificationException.
@@ -20,15 +19,6 @@ class PayoutBatchNotificationException extends PayoutBatchException
     public function __construct($message = "", $code = 205, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutBatchQueryException.php
+++ b/src/BitPaySDK/Exceptions/PayoutBatchQueryException.php
@@ -8,7 +8,6 @@ class PayoutBatchQueryException extends PayoutBatchException
 {
     private $bitPayMessage = "Failed to retrieve payout batch";
     private $bitPayCode    = "BITPAY-PAYOUT-BATCH-GET";
-    protected $apiCode;
 
     /**
      * Construct the PayoutBatchQueryException.
@@ -20,15 +19,6 @@ class PayoutBatchQueryException extends PayoutBatchException
     public function __construct($message = "", $code = 203, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutCancellationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutCancellationException.php
@@ -8,7 +8,6 @@ class PayoutCancellationException extends PayoutException
 {
     private $bitPayMessage = "Failed to cancel payout";
     private $bitPayCode    = "BITPAY-PAYOUT-CANCEL";
-    protected $apiCode;
 
     /**
      * Construct the PayoutCancellationException.
@@ -20,15 +19,6 @@ class PayoutCancellationException extends PayoutException
     public function __construct($message = "", $code = 124, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutCreationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutCreationException.php
@@ -8,7 +8,6 @@ class PayoutCreationException extends PayoutException
 {
     private $bitPayMessage = "Failed to create payout";
     private $bitPayCode    = "BITPAY-PAYOUT-SUBMIT";
-    protected $apiCode;
 
     /**
      * Construct the PayoutCreationException.
@@ -20,15 +19,6 @@ class PayoutCreationException extends PayoutException
     public function __construct($message = "", $code = 122, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
         parent::__construct($message, $code, $previous, $apiCode);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutException.php
+++ b/src/BitPaySDK/Exceptions/PayoutException.php
@@ -8,7 +8,6 @@ class PayoutException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the payout";
     private $bitPayCode    = "BITPAY-PAYOUT-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the PayoutException.
@@ -22,14 +21,6 @@ class PayoutException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutNotificationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutNotificationException.php
@@ -8,7 +8,6 @@ class PayoutNotificationException extends PayoutException
 {
     private $bitPayMessage = "Failed to send payout notification";
     private $bitPayCode    = "BITPAY-PAYOUT-NOTIFICATION";
-    protected $apiCode;
 
     /**
      * Construct the PayoutNotificationException.
@@ -20,15 +19,6 @@ class PayoutNotificationException extends PayoutException
     public function __construct($message = "", $code = 126, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutQueryException.php
+++ b/src/BitPaySDK/Exceptions/PayoutQueryException.php
@@ -8,7 +8,6 @@ class PayoutQueryException extends PayoutException
 {
     private $bitPayMessage = "Failed to retrieve payout batch";
     private $bitPayCode    = "BITPAY-PAYOUT-BATCH-GET";
-    protected $apiCode;
 
     /**
      * Construct the PayoutQueryException.
@@ -20,15 +19,6 @@ class PayoutQueryException extends PayoutException
     public function __construct($message = "", $code = 123, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutRecipientCancellationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutRecipientCancellationException.php
@@ -8,7 +8,6 @@ class PayoutRecipientCancellationException extends PayoutRecipientException
 {
     private $bitPayMessage = "Failed to cancel payout recipient";
     private $bitPayCode    = "BITPAY-PAYOUT-RECIPIENT-CANCEL";
-    protected $apiCode;
 
     /**
      * Construct the PayoutRecipientCancellationException.
@@ -20,15 +19,6 @@ class PayoutRecipientCancellationException extends PayoutRecipientException
     public function __construct($message = "", $code = 194, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutRecipientCreationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutRecipientCreationException.php
@@ -8,7 +8,6 @@ class PayoutRecipientCreationException extends PayoutRecipientException
 {
     private $bitPayMessage = "Failed to create payout recipient";
     private $bitPayCode    = "BITPAY-PAYOUT-RECIPIENT-SUBMIT";
-    protected $apiCode;
 
     /**
      * Construct the PayoutRecipientCreationException.
@@ -20,15 +19,6 @@ class PayoutRecipientCreationException extends PayoutRecipientException
     public function __construct($message = "", $code = 192, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
         parent::__construct($message, $code, $previous, $apiCode);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutRecipientException.php
+++ b/src/BitPaySDK/Exceptions/PayoutRecipientException.php
@@ -8,7 +8,6 @@ class PayoutRecipientException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the payout recipient";
     private $bitPayCode    = "BITPAY-PAYOUT-RECIPIENT-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the PayoutRecipientException.
@@ -22,14 +21,6 @@ class PayoutRecipientException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutRecipientNotificationException.php
+++ b/src/BitPaySDK/Exceptions/PayoutRecipientNotificationException.php
@@ -8,7 +8,6 @@ class PayoutRecipientNotificationException extends PayoutRecipientException
 {
     private $bitPayMessage = "Failed to send payout recipient notification";
     private $bitPayCode    = "BITPAY-PAYOUT-RECIPIENT-NOTIFICATION";
-    protected $apiCode;
 
     /**
      * Construct the PayoutRecipientNotificationException.
@@ -20,15 +19,6 @@ class PayoutRecipientNotificationException extends PayoutRecipientException
     public function __construct($message = "", $code = 196, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutRecipientQueryException.php
+++ b/src/BitPaySDK/Exceptions/PayoutRecipientQueryException.php
@@ -8,7 +8,6 @@ class PayoutRecipientQueryException extends PayoutRecipientException
 {
     private $bitPayMessage = "Failed to retrieve payout recipient";
     private $bitPayCode    = "BITPAY-PAYOUT-RECIPIENT-GET";
-    protected $apiCode;
 
     /**
      * Construct the PayoutRecipientQueryException.
@@ -20,15 +19,6 @@ class PayoutRecipientQueryException extends PayoutRecipientException
     public function __construct($message = "", $code = 193, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutRecipientUpdateException.php
+++ b/src/BitPaySDK/Exceptions/PayoutRecipientUpdateException.php
@@ -8,7 +8,6 @@ class PayoutRecipientUpdateException extends PayoutRecipientException
 {
     private $bitPayMessage = "Failed to update payout recipient";
     private $bitPayCode    = "BITPAY-PAYOUT-RECIPIENT-UPDATE";
-    protected $apiCode;
 
     /**
      * Construct the PayoutRecipientUpdateException.
@@ -20,15 +19,6 @@ class PayoutRecipientUpdateException extends PayoutRecipientException
     public function __construct($message = "", $code = 195, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/PayoutUpdateException.php
+++ b/src/BitPaySDK/Exceptions/PayoutUpdateException.php
@@ -8,7 +8,6 @@ class PayoutUpdateException extends PayoutException
 {
     private $bitPayMessage = "Failed to update payout batch";
     private $bitPayCode    = "BITPAY-PAYOUT-BATCH-UPDATE";
-    protected $apiCode;
 
     /**
      * Construct the PayoutUpdateException.
@@ -20,15 +19,6 @@ class PayoutUpdateException extends PayoutException
     public function __construct($message = "", $code = 125, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/RateException.php
+++ b/src/BitPaySDK/Exceptions/RateException.php
@@ -8,7 +8,6 @@ class RateException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the rates";
     private $bitPayCode    = "BITPAY-RATES-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the RateException.
@@ -22,14 +21,6 @@ class RateException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/RateQueryException.php
+++ b/src/BitPaySDK/Exceptions/RateQueryException.php
@@ -8,7 +8,6 @@ class RateQueryException extends RateException
 {
     private $bitPayMessage = "Failed to retrieve rates";
     private $bitPayCode    = "BITPAY-RATES-GET";
-    protected $apiCode;
 
     /**
      * Construct the RateQueryException.
@@ -20,15 +19,6 @@ class RateQueryException extends RateException
     public function __construct($message = "", $code = 142, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/RefundCancellationException.php
+++ b/src/BitPaySDK/Exceptions/RefundCancellationException.php
@@ -8,7 +8,6 @@ class RefundCancellationException extends RefundException
 {
     private $bitPayMessage = "Failed to cancel refund object";
     private $bitPayCode    = "BITPAY-REFUND-CANCEL";
-    protected $apiCode;
 
     /**
      * Construct the RefundCancellationException.
@@ -20,15 +19,6 @@ class RefundCancellationException extends RefundException
     public function __construct($message = "", $code = 165, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/RefundCreationException.php
+++ b/src/BitPaySDK/Exceptions/RefundCreationException.php
@@ -8,7 +8,6 @@ class RefundCreationException extends RefundException
 {
     private $bitPayMessage = "Failed to create refund";
     private $bitPayCode    = "BITPAY-REFUND-CREATE";
-    protected $apiCode;
 
     /**
      * Construct the RefundCreationException.
@@ -20,15 +19,6 @@ class RefundCreationException extends RefundException
     public function __construct($message = "", $code = 162, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/RefundException.php
+++ b/src/BitPaySDK/Exceptions/RefundException.php
@@ -8,7 +8,6 @@ class RefundException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the refund";
     private $bitPayCode    = "BITPAY-REFUND-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the RefundException.
@@ -22,14 +21,6 @@ class RefundException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/RefundNotificationException.php
+++ b/src/BitPaySDK/Exceptions/RefundNotificationException.php
@@ -2,11 +2,12 @@
 
 namespace BitPaySDK\Exceptions;
 
+use Exception;
+
 class RefundNotificationException extends RefundException
 {
     private $bitPayMessage = "Failed to send refund notification";
     private $bitPayCode    = "BITPAY-REFUND-NOTIFICATION";
-    protected $apiCode;
 
     /**
      * Construct the RefundNotificationException.
@@ -19,15 +20,6 @@ class RefundNotificationException extends RefundException
     {
 
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/RefundQueryException.php
+++ b/src/BitPaySDK/Exceptions/RefundQueryException.php
@@ -8,7 +8,6 @@ class RefundQueryException extends RefundException
 {
     private $bitPayMessage = "Failed to retrieve refund";
     private $bitPayCode    = "BITPAY-REFUND-GET";
-    protected $apiCode;
 
     /**
      * Construct the RefundQueryException.
@@ -20,15 +19,6 @@ class RefundQueryException extends RefundException
     public function __construct($message = "", $code = 163, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/RefundUpdateException.php
+++ b/src/BitPaySDK/Exceptions/RefundUpdateException.php
@@ -2,11 +2,12 @@
 
 namespace BitPaySDK\Exceptions;
 
+use Exception;
+
 class RefundUpdateException extends RefundException
 {
     private $bitPayMessage = "Failed to update refund";
     private $bitPayCode    = "BITPAY-REFUND-UPDATE";
-    protected $apiCode;
 
     /**
      * Construct the RefundUpdateException.
@@ -19,15 +20,6 @@ class RefundUpdateException extends RefundException
     {
 
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/SettlementException.php
+++ b/src/BitPaySDK/Exceptions/SettlementException.php
@@ -8,7 +8,6 @@ class SettlementException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the settlements";
     private $bitPayCode    = "BITPAY-SETTLEMENTS-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the SettlementException.
@@ -22,14 +21,6 @@ class SettlementException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/SettlementQueryException.php
+++ b/src/BitPaySDK/Exceptions/SettlementQueryException.php
@@ -8,7 +8,6 @@ class SettlementQueryException extends SettlementException
 {
     private $bitPayMessage = "Failed to retrieve settlements";
     private $bitPayCode    = "BITPAY-SETTLEMENTS-GET";
-    protected $apiCode;
 
     /**
      * Construct the SettlementQueryException.
@@ -20,15 +19,6 @@ class SettlementQueryException extends SettlementException
     public function __construct($message = "", $code = 152, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/SubscriptionCreationException.php
+++ b/src/BitPaySDK/Exceptions/SubscriptionCreationException.php
@@ -8,7 +8,6 @@ class SubscriptionCreationException extends SubscriptionException
 {
     private $bitPayMessage = "Failed to create subscription";
     private $bitPayCode    = "BITPAY-SUBSCRIPTION-CREATE";
-    protected $apiCode;
 
     /**
      * Construct the SubscriptionCreationException.
@@ -20,15 +19,6 @@ class SubscriptionCreationException extends SubscriptionException
     public function __construct($message = "", $code = 172, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/SubscriptionException.php
+++ b/src/BitPaySDK/Exceptions/SubscriptionException.php
@@ -8,7 +8,6 @@ class SubscriptionException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the subscription";
     private $bitPayCode    = "BITPAY-SUBSCRIPTION-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the SubscriptionException.
@@ -22,14 +21,6 @@ class SubscriptionException extends BitPayException
         if (!$message) {
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/SubscriptionQueryException.php
+++ b/src/BitPaySDK/Exceptions/SubscriptionQueryException.php
@@ -8,7 +8,6 @@ class SubscriptionQueryException extends SubscriptionException
 {
     private $bitPayMessage = "Failed to retrieve subscription";
     private $bitPayCode    = "BITPAY-SUBSCRIPTION-GET";
-    protected $apiCode;
 
     /**
      * Construct the SubscriptionQueryException.
@@ -20,15 +19,6 @@ class SubscriptionQueryException extends SubscriptionException
     public function __construct($message = "", $code = 173, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/SubscriptionUpdateException.php
+++ b/src/BitPaySDK/Exceptions/SubscriptionUpdateException.php
@@ -8,7 +8,6 @@ class SubscriptionUpdateException extends SubscriptionException
 {
     private $bitPayMessage = "Failed to update subscription";
     private $bitPayCode    = "BITPAY-SUBSCRIPTION-UPDATE";
-    protected $apiCode;
 
     /**
      * Construct the SubscriptionUpdateException.
@@ -20,15 +19,6 @@ class SubscriptionUpdateException extends SubscriptionException
     public function __construct($message = "", $code = 174, Exception $previous = null, $apiCode = "000000")
     {
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/WalletException.php
+++ b/src/BitPaySDK/Exceptions/WalletException.php
@@ -6,7 +6,6 @@ class WalletException extends BitPayException
 {
     private $bitPayMessage = "An unexpected error occurred while trying to manage the wallet";
     private $bitPayCode    = "BITPAY-WALLET-GENERIC";
-    protected $apiCode;
 
     /**
      * Construct the WalletException.
@@ -21,14 +20,6 @@ class WalletException extends BitPayException
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
 
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/src/BitPaySDK/Exceptions/WalletQueryException.php
+++ b/src/BitPaySDK/Exceptions/WalletQueryException.php
@@ -2,11 +2,12 @@
 
 namespace BitPaySDK\Exceptions;
 
+use Exception;
+
 class WalletQueryException extends WalletException
 {
     private $bitPayMessage = "Failed to retrieve supported wallets";
     private $bitPayCode    = "BITPAY-WALLET-GET";
-    protected $apiCode;
 
     /**
      * Construct the WalletQueryException.
@@ -19,15 +20,6 @@ class WalletQueryException extends WalletException
     {
 
         $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
-        $this->apiCode = $apiCode;
-        parent::__construct($message, $code, $previous);
-    }
-
-    /**
-     * @return string Error code provided by the BitPay REST API
-     */
-    public function getApiCode()
-    {
-        return $this->apiCode;
+        parent::__construct($message, $code, $previous, $apiCode);
     }
 }

--- a/test/unit/BitPaySDK/Exceptions/BillCreationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BillCreationExceptionTest.php
@@ -2,10 +2,10 @@
 
 namespace BitPaySDK\Test\Exceptions;
 
-use BitPaySDK\Exceptions\BillException;
+use BitPaySDK\Exceptions\BillCreationException;
 use PHPUnit\Framework\TestCase;
 
-class BillExceptionTest extends TestCase
+class BillCreationExceptionTest extends TestCase
 {
 
   public function testDefaultApiCode()
@@ -18,7 +18,7 @@ class BillExceptionTest extends TestCase
   public function testInstanceOf()
   {
     $exception = $this->createClassObject();
-    $this->assertInstanceOf(BillException::class, $exception);
+    $this->assertInstanceOf(BillCreationException::class, $exception);
   }
 
   public function testDefaultMessage()
@@ -26,7 +26,7 @@ class BillExceptionTest extends TestCase
     $exception = $this->createClassObject();
     
     $this->assertEquals(
-      'BITPAY-BILL-GENERIC: An unexpected error occurred while trying to manage the bill-> ',
+      'BITPAY-BILL-CREATE: Failed to create bill-> ',
       $exception->getMessage()
     );
   }
@@ -35,14 +35,14 @@ class BillExceptionTest extends TestCase
   {
     $exception = $this->createClassObject();
     
-    $this->assertEquals(111, $exception->getCode());
+    $this->assertEquals(112, $exception->getCode());
   }
 
   public function testGetApiCode()
   {
-    $exception = new BillException(
+    $exception = new BillCreationException(
       'My test message',
-      111,
+      112,
       null,
       'CUSTOM-API-CODE'
     );
@@ -52,6 +52,6 @@ class BillExceptionTest extends TestCase
 
   private function createClassObject()
   {
-    return new BillException();
+    return new BillCreationException();
   }
 }

--- a/test/unit/BitPaySDK/Exceptions/BillDeliveryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BillDeliveryExceptionTest.php
@@ -2,10 +2,10 @@
 
 namespace BitPaySDK\Test\Exceptions;
 
-use BitPaySDK\Exceptions\BillException;
+use BitPaySDK\Exceptions\BillDeliveryException;
 use PHPUnit\Framework\TestCase;
 
-class BillExceptionTest extends TestCase
+class BillDeliveryExceptionTest extends TestCase
 {
 
   public function testDefaultApiCode()
@@ -18,7 +18,7 @@ class BillExceptionTest extends TestCase
   public function testInstanceOf()
   {
     $exception = $this->createClassObject();
-    $this->assertInstanceOf(BillException::class, $exception);
+    $this->assertInstanceOf(BillDeliveryException::class, $exception);
   }
 
   public function testDefaultMessage()
@@ -26,7 +26,7 @@ class BillExceptionTest extends TestCase
     $exception = $this->createClassObject();
     
     $this->assertEquals(
-      'BITPAY-BILL-GENERIC: An unexpected error occurred while trying to manage the bill-> ',
+      'BITPAY-BILL-DELIVERY: Failed to deliver bill-> ',
       $exception->getMessage()
     );
   }
@@ -35,14 +35,14 @@ class BillExceptionTest extends TestCase
   {
     $exception = $this->createClassObject();
     
-    $this->assertEquals(111, $exception->getCode());
+    $this->assertEquals(115, $exception->getCode());
   }
 
   public function testGetApiCode()
   {
-    $exception = new BillException(
+    $exception = new BillDeliveryException(
       'My test message',
-      111,
+      115,
       null,
       'CUSTOM-API-CODE'
     );
@@ -52,6 +52,6 @@ class BillExceptionTest extends TestCase
 
   private function createClassObject()
   {
-    return new BillException();
+    return new BillDeliveryException();
   }
 }

--- a/test/unit/BitPaySDK/Exceptions/BillExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BillExceptionTest.php
@@ -7,6 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 class BillExceptionTest extends TestCase
 {
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(null, $exception->getApiCode());
+  }
+
   public function testInstanceOf()
   {
     $exception = $this->createClassObject();
@@ -27,10 +35,7 @@ class BillExceptionTest extends TestCase
   {
     $exception = $this->createClassObject();
     
-    $this->assertEquals(
-      111,
-      $exception->getCode()
-    );
+    $this->assertEquals(111, $exception->getCode());
   }
 
   // public function testGetApiCode()

--- a/test/unit/BitPaySDK/Exceptions/BillExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BillExceptionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\BillException;
+use PHPUnit\Framework\TestCase;
+
+class BillExceptionTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(BillException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-BILL-GENERIC: An unexpected error occurred while trying to manage the bill-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      111,
+      $exception->getCode()
+    );
+  }
+
+  // public function testGetApiCode()
+  // {
+  //   $exception = new BillException(
+  //     'My test message',
+  //     111,
+  //     null,
+  //     'CUSTOM-API-CODE'
+  //   );
+
+  //   $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  // }
+
+  private function createClassObject()
+  {
+    return new BillException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/BillQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BillQueryExceptionTest.php
@@ -2,10 +2,10 @@
 
 namespace BitPaySDK\Test\Exceptions;
 
-use BitPaySDK\Exceptions\BillException;
+use BitPaySDK\Exceptions\BillQueryException;
 use PHPUnit\Framework\TestCase;
 
-class BillExceptionTest extends TestCase
+class BillQueryExceptionTest extends TestCase
 {
 
   public function testDefaultApiCode()
@@ -18,7 +18,7 @@ class BillExceptionTest extends TestCase
   public function testInstanceOf()
   {
     $exception = $this->createClassObject();
-    $this->assertInstanceOf(BillException::class, $exception);
+    $this->assertInstanceOf(BillQueryException::class, $exception);
   }
 
   public function testDefaultMessage()
@@ -26,7 +26,7 @@ class BillExceptionTest extends TestCase
     $exception = $this->createClassObject();
     
     $this->assertEquals(
-      'BITPAY-BILL-GENERIC: An unexpected error occurred while trying to manage the bill-> ',
+      'BITPAY-BILL-GET: Failed to retrieve bill-> ',
       $exception->getMessage()
     );
   }
@@ -35,14 +35,14 @@ class BillExceptionTest extends TestCase
   {
     $exception = $this->createClassObject();
     
-    $this->assertEquals(111, $exception->getCode());
+    $this->assertEquals(113, $exception->getCode());
   }
 
   public function testGetApiCode()
   {
-    $exception = new BillException(
+    $exception = new BillQueryException(
       'My test message',
-      111,
+      113,
       null,
       'CUSTOM-API-CODE'
     );
@@ -52,6 +52,6 @@ class BillExceptionTest extends TestCase
 
   private function createClassObject()
   {
-    return new BillException();
+    return new BillQueryException();
   }
 }

--- a/test/unit/BitPaySDK/Exceptions/BillUpdateExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BillUpdateExceptionTest.php
@@ -2,10 +2,10 @@
 
 namespace BitPaySDK\Test\Exceptions;
 
-use BitPaySDK\Exceptions\BillException;
+use BitPaySDK\Exceptions\BillUpdateException;
 use PHPUnit\Framework\TestCase;
 
-class BillExceptionTest extends TestCase
+class BillUpdateExceptionTest extends TestCase
 {
 
   public function testDefaultApiCode()
@@ -18,7 +18,7 @@ class BillExceptionTest extends TestCase
   public function testInstanceOf()
   {
     $exception = $this->createClassObject();
-    $this->assertInstanceOf(BillException::class, $exception);
+    $this->assertInstanceOf(BillUpdateException::class, $exception);
   }
 
   public function testDefaultMessage()
@@ -26,7 +26,7 @@ class BillExceptionTest extends TestCase
     $exception = $this->createClassObject();
     
     $this->assertEquals(
-      'BITPAY-BILL-GENERIC: An unexpected error occurred while trying to manage the bill-> ',
+      'BITPAY-BILL-UPDATE: Failed to update bill-> ',
       $exception->getMessage()
     );
   }
@@ -35,14 +35,14 @@ class BillExceptionTest extends TestCase
   {
     $exception = $this->createClassObject();
     
-    $this->assertEquals(111, $exception->getCode());
+    $this->assertEquals(114, $exception->getCode());
   }
 
   public function testGetApiCode()
   {
-    $exception = new BillException(
+    $exception = new BillUpdateException(
       'My test message',
-      111,
+      114,
       null,
       'CUSTOM-API-CODE'
     );
@@ -52,6 +52,6 @@ class BillExceptionTest extends TestCase
 
   private function createClassObject()
   {
-    return new BillException();
+    return new BillUpdateException();
   }
 }

--- a/test/unit/BitPaySDK/Exceptions/BitPayExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BitPayExceptionTest.php
@@ -13,6 +13,20 @@ class BitPayExceptionTest extends TestCase
     $this->assertInstanceOf(BitPayException::class, $exception);
   }
 
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(null, $exception->getApiCode());
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(100, $exception->getCode());
+  }
+
   public function testDefaultMessage()
   {
     $exception = $this->createClassObject();
@@ -20,16 +34,6 @@ class BitPayExceptionTest extends TestCase
     $this->assertEquals(
       'BITPAY-GENERIC: Unexpected Bitpay exeption.-> ',
       $exception->getMessage()
-    );
-  }
-
-  public function testDefaultCode()
-  {
-    $exception = $this->createClassObject();
-    
-    $this->assertEquals(
-      100,
-      $exception->getCode()
     );
   }
 

--- a/test/unit/BitPaySDK/Exceptions/BitPayExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BitPayExceptionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\BitPayException;
+use PHPUnit\Framework\TestCase;
+
+class BitPayExceptionTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(BitPayException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-GENERIC: Unexpected Bitpay exeption.-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      100,
+      $exception->getCode()
+    );
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new BitPayException(
+      'My test message',
+      100,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new BitPayException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/CurrencyExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/CurrencyExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\CurrencyException;
+use PHPUnit\Framework\TestCase;
+
+class CurrencyExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(CurrencyException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-CURRENCY-GENERIC: An unexpected error occurred while trying to manage the currencies-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(181, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new CurrencyException(
+      'My test message',
+      181,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new CurrencyException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/CurrencyQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/CurrencyQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\CurrencyQueryException;
+use PHPUnit\Framework\TestCase;
+
+class CurrencyQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(CurrencyQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-CURRENCY-GET: Failed to retrieve currencies-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(182, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new CurrencyQueryException(
+      'My test message',
+      182,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new CurrencyQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/InvoiceCancellationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/InvoiceCancellationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\InvoiceCancellationException;
+use PHPUnit\Framework\TestCase;
+
+class InvoiceCancellationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(InvoiceCancellationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-INVOICE-CANCEL: Failed to cancel invoice object-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(105, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new InvoiceCancellationException(
+      'My test message',
+      105,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new InvoiceCancellationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/InvoiceCreationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/InvoiceCreationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\InvoiceCreationException;
+use PHPUnit\Framework\TestCase;
+
+class InvoiceCreationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(InvoiceCreationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-INVOICE-CREATE: Failed to create invoice-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(102, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new InvoiceCreationException(
+      'My test message',
+      102,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new InvoiceCreationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/InvoiceExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/InvoiceExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\InvoiceException;
+use PHPUnit\Framework\TestCase;
+
+class InvoiceExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(InvoiceException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-INVOICE-GENERIC: An unexpected error occurred while trying to manage the invoice-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(101, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new InvoiceException(
+      'My test message',
+      101,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new InvoiceException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/InvoicePaymentExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/InvoicePaymentExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\InvoicePaymentException;
+use PHPUnit\Framework\TestCase;
+
+class InvoicePaymentExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(InvoicePaymentException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-INVOICE-PAY-UPDATE: Failed to pay invoice-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(107, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new InvoicePaymentException(
+      'My test message',
+      107,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new InvoicePaymentException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/InvoiceQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/InvoiceQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\InvoiceQueryException;
+use PHPUnit\Framework\TestCase;
+
+class InvoiceQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(InvoiceQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-INVOICE-GET: Failed to retrieve invoice-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(103, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new InvoiceQueryException(
+      'My test message',
+      103,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new InvoiceQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/LedgerExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/LedgerExceptionTest.php
@@ -2,10 +2,10 @@
 
 namespace BitPaySDK\Test\Exceptions;
 
-use BitPaySDK\Exceptions\InvoiceUpdateException;
+use BitPaySDK\Exceptions\LedgerException;
 use PHPUnit\Framework\TestCase;
 
-class InvoiceUpdateExceptionTest extends TestCase
+class LedgerExceptionTest extends TestCase
 {
 
   public function testDefaultApiCode()
@@ -18,7 +18,7 @@ class InvoiceUpdateExceptionTest extends TestCase
   public function testInstanceOf()
   {
     $exception = $this->createClassObject();
-    $this->assertInstanceOf(InvoiceUpdateException::class, $exception);
+    $this->assertInstanceOf(LedgerException::class, $exception);
   }
 
   public function testDefaultMessage()
@@ -26,7 +26,7 @@ class InvoiceUpdateExceptionTest extends TestCase
     $exception = $this->createClassObject();
     
     $this->assertEquals(
-      'BITPAY-INVOICE-UPDATE: Failed to update invoice-> ',
+      'BITPAY-LEDGER-GENERIC: An unexpected error occurred while trying to manage the ledger-> ',
       $exception->getMessage()
     );
   }
@@ -35,14 +35,14 @@ class InvoiceUpdateExceptionTest extends TestCase
   {
     $exception = $this->createClassObject();
     
-    $this->assertEquals(104, $exception->getCode());
+    $this->assertEquals(131, $exception->getCode());
   }
 
   public function testGetApiCode()
   {
-    $exception = new InvoiceUpdateException(
+    $exception = new LedgerException(
       'My test message',
-      104,
+      131,
       null,
       'CUSTOM-API-CODE'
     );
@@ -52,6 +52,6 @@ class InvoiceUpdateExceptionTest extends TestCase
 
   private function createClassObject()
   {
-    return new InvoiceUpdateException();
+    return new LedgerException();
   }
 }

--- a/test/unit/BitPaySDK/Exceptions/LedgerQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/LedgerQueryExceptionTest.php
@@ -2,10 +2,10 @@
 
 namespace BitPaySDK\Test\Exceptions;
 
-use BitPaySDK\Exceptions\InvoiceUpdateException;
+use BitPaySDK\Exceptions\LedgerQueryException;
 use PHPUnit\Framework\TestCase;
 
-class InvoiceUpdateExceptionTest extends TestCase
+class LedgerQueryExceptionTest extends TestCase
 {
 
   public function testDefaultApiCode()
@@ -18,7 +18,7 @@ class InvoiceUpdateExceptionTest extends TestCase
   public function testInstanceOf()
   {
     $exception = $this->createClassObject();
-    $this->assertInstanceOf(InvoiceUpdateException::class, $exception);
+    $this->assertInstanceOf(LedgerQueryException::class, $exception);
   }
 
   public function testDefaultMessage()
@@ -26,7 +26,7 @@ class InvoiceUpdateExceptionTest extends TestCase
     $exception = $this->createClassObject();
     
     $this->assertEquals(
-      'BITPAY-INVOICE-UPDATE: Failed to update invoice-> ',
+      'BITPAY-LEDGER-GET: Failed to retrieve ledger-> ',
       $exception->getMessage()
     );
   }
@@ -35,14 +35,14 @@ class InvoiceUpdateExceptionTest extends TestCase
   {
     $exception = $this->createClassObject();
     
-    $this->assertEquals(104, $exception->getCode());
+    $this->assertEquals(132, $exception->getCode());
   }
 
   public function testGetApiCode()
   {
-    $exception = new InvoiceUpdateException(
+    $exception = new LedgerQueryException(
       'My test message',
-      104,
+      132,
       null,
       'CUSTOM-API-CODE'
     );
@@ -52,6 +52,6 @@ class InvoiceUpdateExceptionTest extends TestCase
 
   private function createClassObject()
   {
-    return new InvoiceUpdateException();
+    return new LedgerQueryException();
   }
 }

--- a/test/unit/BitPaySDK/Exceptions/PayoutBatchCancellationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutBatchCancellationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutBatchCancellationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutBatchCancellationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutBatchCancellationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-BATCH-CANCEL: Failed to cancel payout batch-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(204, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutBatchCancellationException(
+      'My test message',
+      204,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutBatchCancellationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutBatchCreationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutBatchCreationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutBatchCreationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutBatchCreationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutBatchCreationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-BATCH-SUBMIT: Failed to create payout batch-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(202, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutBatchCreationException(
+      'My test message',
+      202,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutBatchCreationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutBatchExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutBatchExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutBatchException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutBatchExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutBatchException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-BATCH-GENERIC: An unexpected error occurred while trying to manage the payout batch-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(201, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutBatchException(
+      'My test message',
+      201,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutBatchException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutBatchNotificationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutBatchNotificationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutBatchNotificationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutBatchNotificationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutBatchNotificationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-BATCH-NOTIFICATION: Failed to send payout batch notification-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(205, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutBatchNotificationException(
+      'My test message',
+      205,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutBatchNotificationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutBatchQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutBatchQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutBatchQueryException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutBatchQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutBatchQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-BATCH-GET: Failed to retrieve payout batch-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(203, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutBatchQueryException(
+      'My test message',
+      203,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutBatchQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutCancellationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutCancellationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutCancellationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutCancellationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutCancellationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-CANCEL: Failed to cancel payout-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(124, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutCancellationException(
+      'My test message',
+      124,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutCancellationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutCreationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutCreationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutCreationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutCreationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutCreationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-SUBMIT: Failed to create payout-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(122, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutCreationException(
+      'My test message',
+      122,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutCreationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-GENERIC: An unexpected error occurred while trying to manage the payout-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(121, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutException(
+      'My test message',
+      121,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutNotificationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutNotificationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutNotificationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutNotificationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutNotificationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-NOTIFICATION: Failed to send payout notification-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(126, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutNotificationException(
+      'My test message',
+      126,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutNotificationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutQueryException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-BATCH-GET: Failed to retrieve payout batch-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(123, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutQueryException(
+      'My test message',
+      123,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutRecipientCancellationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutRecipientCancellationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutRecipientCancellationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutRecipientCancellationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutRecipientCancellationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-RECIPIENT-CANCEL: Failed to cancel payout recipient-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(194, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutRecipientCancellationException(
+      'My test message',
+      194,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutRecipientCancellationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutRecipientCreationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutRecipientCreationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutRecipientCreationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutRecipientCreationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutRecipientCreationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-RECIPIENT-SUBMIT: Failed to create payout recipient-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(192, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutRecipientCreationException(
+      'My test message',
+      192,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutRecipientCreationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutRecipientExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutRecipientExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutRecipientException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutRecipientExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutRecipientException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-RECIPIENT-GENERIC: An unexpected error occurred while trying to manage the payout recipient-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(191, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutRecipientException(
+      'My test message',
+      191,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutRecipientException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutRecipientNotificationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutRecipientNotificationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutRecipientNotificationException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutRecipientNotificationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutRecipientNotificationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-RECIPIENT-NOTIFICATION: Failed to send payout recipient notification-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(196, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutRecipientNotificationException(
+      'My test message',
+      196,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutRecipientNotificationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutRecipientQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutRecipientQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutRecipientQueryException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutRecipientQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutRecipientQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-RECIPIENT-GET: Failed to retrieve payout recipient-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(193, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutRecipientQueryException(
+      'My test message',
+      193,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutRecipientQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutRecipientUpdateExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutRecipientUpdateExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutRecipientUpdateException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutRecipientUpdateExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutRecipientUpdateException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-RECIPIENT-UPDATE: Failed to update payout recipient-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(195, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutRecipientUpdateException(
+      'My test message',
+      195,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutRecipientUpdateException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/PayoutUpdateExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/PayoutUpdateExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\PayoutUpdateException;
+use PHPUnit\Framework\TestCase;
+
+class PayoutUpdateExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(PayoutUpdateException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-PAYOUT-BATCH-UPDATE: Failed to update payout batch-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(125, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new PayoutUpdateException(
+      'My test message',
+      125,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutUpdateException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/RateExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/RateExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\RateException;
+use PHPUnit\Framework\TestCase;
+
+class RateExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(RateException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-RATES-GENERIC: An unexpected error occurred while trying to manage the rates-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(141, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new RateException(
+      'My test message',
+      141,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new RateException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/RateQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/RateQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\RateQueryException;
+use PHPUnit\Framework\TestCase;
+
+class RateQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(RateQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-RATES-GET: Failed to retrieve rates-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(142, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new RateQueryException(
+      'My test message',
+      142,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new RateQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/RefundCancellationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/RefundCancellationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\RefundCancellationException;
+use PHPUnit\Framework\TestCase;
+
+class RefundCancellationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(RefundCancellationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-REFUND-CANCEL: Failed to cancel refund object-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(165, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new RefundCancellationException(
+      'My test message',
+      165,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new RefundCancellationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/RefundCreationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/RefundCreationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\RefundCreationException;
+use PHPUnit\Framework\TestCase;
+
+class RefundCreationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(RefundCreationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-REFUND-CREATE: Failed to create refund-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(162, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new RefundCreationException(
+      'My test message',
+      162,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new RefundCreationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/RefundExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/RefundExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\RefundException;
+use PHPUnit\Framework\TestCase;
+
+class RefundExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(RefundException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-REFUND-GENERIC: An unexpected error occurred while trying to manage the refund-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(161, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new RefundException(
+      'My test message',
+      161,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new RefundException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/RefundNotificationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/RefundNotificationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\RefundNotificationException;
+use PHPUnit\Framework\TestCase;
+
+class RefundNotificationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(RefundNotificationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-REFUND-NOTIFICATION: Failed to send refund notification-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(166, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new RefundNotificationException(
+      'My test message',
+      166,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new RefundNotificationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/RefundQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/RefundQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\RefundQueryException;
+use PHPUnit\Framework\TestCase;
+
+class RefundQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(RefundQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-REFUND-GET: Failed to retrieve refund-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(163, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new RefundQueryException(
+      'My test message',
+      163,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new RefundQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/RefundUpdateExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/RefundUpdateExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\RefundUpdateException;
+use PHPUnit\Framework\TestCase;
+
+class RefundUpdateExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(RefundUpdateException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-REFUND-UPDATE: Failed to update refund-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(164, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new RefundUpdateException(
+      'My test message',
+      164,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new RefundUpdateException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/SettlementExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/SettlementExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\SettlementException;
+use PHPUnit\Framework\TestCase;
+
+class SettlementExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(SettlementException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-SETTLEMENTS-GENERIC: An unexpected error occurred while trying to manage the settlements-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(151, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new SettlementException(
+      'My test message',
+      151,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new SettlementException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/SettlementQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/SettlementQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\SettlementQueryException;
+use PHPUnit\Framework\TestCase;
+
+class SettlementQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(SettlementQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-SETTLEMENTS-GET: Failed to retrieve settlements-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(152, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new SettlementQueryException(
+      'My test message',
+      152,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new SettlementQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/SubscriptionCreationExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/SubscriptionCreationExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\SubscriptionCreationException;
+use PHPUnit\Framework\TestCase;
+
+class SubscriptionCreationExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(SubscriptionCreationException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-SUBSCRIPTION-CREATE: Failed to create subscription-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(172, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new SubscriptionCreationException(
+      'My test message',
+      172,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new SubscriptionCreationException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/SubscriptionExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/SubscriptionExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\SubscriptionException;
+use PHPUnit\Framework\TestCase;
+
+class SubscriptionExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(SubscriptionException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-SUBSCRIPTION-GENERIC: An unexpected error occurred while trying to manage the subscription-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(171, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new SubscriptionException(
+      'My test message',
+      171,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new SubscriptionException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/SubscriptionQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/SubscriptionQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\SubscriptionQueryException;
+use PHPUnit\Framework\TestCase;
+
+class SubscriptionQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(SubscriptionQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-SUBSCRIPTION-GET: Failed to retrieve subscription-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(173, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new SubscriptionQueryException(
+      'My test message',
+      173,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new SubscriptionQueryException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/SubscriptionUpdateExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/SubscriptionUpdateExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\SubscriptionUpdateException;
+use PHPUnit\Framework\TestCase;
+
+class SubscriptionUpdateExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(SubscriptionUpdateException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-SUBSCRIPTION-UPDATE: Failed to update subscription-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(174, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new SubscriptionUpdateException(
+      'My test message',
+      174,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new SubscriptionUpdateException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/WalletExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/WalletExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\WalletException;
+use PHPUnit\Framework\TestCase;
+
+class WalletExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(WalletException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-WALLET-GENERIC: An unexpected error occurred while trying to manage the wallet-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(181, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new WalletException(
+      'My test message',
+      181,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new WalletException();
+  }
+}

--- a/test/unit/BitPaySDK/Exceptions/WalletQueryExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/WalletQueryExceptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitPaySDK\Test\Exceptions;
+
+use BitPaySDK\Exceptions\WalletQueryException;
+use PHPUnit\Framework\TestCase;
+
+class WalletQueryExceptionTest extends TestCase
+{
+
+  public function testDefaultApiCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals('000000', $exception->getApiCode());
+  }
+
+  public function testInstanceOf()
+  {
+    $exception = $this->createClassObject();
+    $this->assertInstanceOf(WalletQueryException::class, $exception);
+  }
+
+  public function testDefaultMessage()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(
+      'BITPAY-WALLET-GET: Failed to retrieve supported wallets-> ',
+      $exception->getMessage()
+    );
+  }
+
+  public function testDefaultCode()
+  {
+    $exception = $this->createClassObject();
+    
+    $this->assertEquals(183, $exception->getCode());
+  }
+
+  public function testGetApiCode()
+  {
+    $exception = new WalletQueryException(
+      'My test message',
+      183,
+      null,
+      'CUSTOM-API-CODE'
+    );
+
+    $this->assertEquals('CUSTOM-API-CODE', $exception->getApiCode());
+  }
+
+  private function createClassObject()
+  {
+    return new WalletQueryException();
+  }
+}


### PR DESCRIPTION
# Overview

This pull request aims to accomplish two things:

* Simplify exceptions by removing unnecessary code
* Add unit test coverage for all exceptions

It also addresses a few issues:
* Some exception classes were referencing `Exception` but did not `use Exception;`
* The setting of the `$apiCode` property was being overridden due to its placement, and `null` was always returned
* Excludes `JsonMapper` from test coverage since that's third-party and should be moved to Composer