### PR TITLE
SP-124 Payout Tests

### DIFF
--- a/src/BitPaySDK/Model/Payout/Payout.php
+++ b/src/BitPaySDK/Model/Payout/Payout.php
@@ -11,21 +11,21 @@ use BitPaySDK\Model\Currency;
  */
 class Payout
 {
-    protected $_token = "";
+    protected $_token = '';
 
     protected $_amount       = 0.0;
-    protected $_currency     = "";
+    protected $_currency     = '';
     protected $_effectiveDate;
-    protected $_ledgerCurrency = "";
+    protected $_ledgerCurrency = '';
 
-    protected $_reference         = "";
-    protected $_notificationUrl   = "";
-    protected $_notificationEmail = "";
-    protected $_email = "";
-    protected $_recipientId = "";
-    protected $_shopperId = "";
-    protected $_label = "";
-    protected $_message = "";
+    protected $_reference         = '';
+    protected $_notificationUrl   = '';
+    protected $_notificationEmail = '';
+    protected $_email = '';
+    protected $_recipientId = '';
+    protected $_shopperId = '';
+    protected $_label = '';
+    protected $_message = '';
 
     protected $_id;
     protected $_status;

--- a/src/BitPaySDK/Model/Payout/Payout.php
+++ b/src/BitPaySDK/Model/Payout/Payout.php
@@ -2,7 +2,6 @@
 
 namespace BitPaySDK\Model\Payout;
 
-use BitPaySDK;
 use BitPaySDK\Exceptions\BitPayException;
 use BitPaySDK\Model\Currency;
 
@@ -250,7 +249,17 @@ class Payout
 
     public function getTransactions()
     {
-        return $this->_transactions;
+        $transactions = [];
+
+        foreach ($this->_transactions as $transaction) {
+            if ($transaction instanceof PayoutTransaction) {
+                array_push($transactions, $transaction->toArray());
+            } else {
+                array_push($transactions, $transaction);
+            }
+        }
+
+        return $transactions;
     }
 
     public function setTransactions(array $transactions)
@@ -278,7 +287,7 @@ class Payout
             'status'            => $this->getStatus(),
             'requestDate'       => $this->getRequestDate(),
             'exchangeRates'     => $this->getExchangeRates(),
-            'transactions'      => $this->getTransactions()->toArray()
+            'transactions'      => $this->getTransactions()
         ];
 
         foreach ($elements as $key => $value) {

--- a/src/BitPaySDK/Model/Payout/PayoutBatch.php
+++ b/src/BitPaySDK/Model/Payout/PayoutBatch.php
@@ -2,7 +2,6 @@
 
 namespace BitPaySDK\Model\Payout;
 
-use BitPaySDK;
 use BitPaySDK\Exceptions\BitPayException;
 use BitPaySDK\Model\Currency;
 
@@ -12,22 +11,22 @@ use BitPaySDK\Model\Currency;
  */
 class PayoutBatch
 {
-    protected $_token = "";
+    protected $_token = '';
 
     protected $_amount       = 0.0;
-    protected $_currency     = "";
+    protected $_currency     = '';
     protected $_effectiveDate;
     protected $_instructions = [];
-    protected $_ledgerCurrency = "";
+    protected $_ledgerCurrency = '';
 
-    protected $_reference         = "";
-    protected $_notificationUrl   = "";
-    protected $_notificationEmail = "";
-    protected $_email = "";
-    protected $_recipientId = "";
-    protected $_shopperId = "";
-    protected $_label = "";
-    protected $_message = "";
+    protected $_reference         = '';
+    protected $_notificationUrl   = '';
+    protected $_notificationEmail = '';
+    protected $_email = '';
+    protected $_recipientId = '';
+    protected $_shopperId = '';
+    protected $_label = '';
+    protected $_message = '';
 
     protected $_id;
     protected $_account;
@@ -72,7 +71,7 @@ class PayoutBatch
                 if ($instruction instanceof PayoutInstruction) {
                     $amount += $instruction->getAmount();
                 } else {
-                    $amount += $instruction->amount;
+                    $amount += $instruction['amount'];
                 }
             }
         }

--- a/src/BitPaySDK/Model/Payout/PayoutInstruction.php
+++ b/src/BitPaySDK/Model/Payout/PayoutInstruction.php
@@ -15,7 +15,7 @@ class PayoutInstruction
     protected $_email;
     protected $_recipientId;
     protected $_shopperId;
-    protected $_label = "";
+    protected $_label = '';
     protected $_id;
 
     /**

--- a/src/BitPaySDK/Model/Payout/PayoutReceivedInfo.php
+++ b/src/BitPaySDK/Model/Payout/PayoutReceivedInfo.php
@@ -52,6 +52,12 @@ class PayoutReceivedInfo
 
     public function toArray()
     {
+        /**
+         * @todo In a future version, instead of removing values that are not
+         *       set, update this logic to only include elements that *are*
+         *       set. This will mitigate errors when calling toArray() on
+         *       elements that are not set. This should be done universally.
+         */
         $elements = [
             'name'    => $this->getName(),
             'email'   => $this->getEmail(),

--- a/src/BitPaySDK/Model/Payout/PayoutRecipient.php
+++ b/src/BitPaySDK/Model/Payout/PayoutRecipient.php
@@ -2,8 +2,6 @@
 
 namespace BitPaySDK\Model\Payout;
 
-use BitPaySDK;
-
 /**
  *
  * @package Bitpay

--- a/src/BitPaySDK/Model/Payout/PayoutRecipient.php
+++ b/src/BitPaySDK/Model/Payout/PayoutRecipient.php
@@ -97,7 +97,7 @@ class PayoutRecipient
 
     public function getAccount()
     {
-        return $this->account;
+        return $this->_account;
     }
 
     public function setAccount(string $account)

--- a/src/BitPaySDK/Model/Payout/PayoutRecipients.php
+++ b/src/BitPaySDK/Model/Payout/PayoutRecipients.php
@@ -2,17 +2,15 @@
 
 namespace BitPaySDK\Model\Payout;
 
-use BitPaySDK;
-
 /**
  *
  * @package Bitpay
  */
 class PayoutRecipients
 {
-    protected $_guid  = "";
+    protected $_guid  = '';
     protected $_recipients = [];
-    protected $_token      = "";
+    protected $_token      = '';
 
     /**
      * Constructor, create an recipient-full request PayoutBatch object.
@@ -73,6 +71,7 @@ class PayoutRecipients
     public function toArray()
     {
         $elements = [
+            'guid'       => $this->getGuid(),
             'recipients' => $this->getRecipients(),
             'token'      => $this->getToken(),
         ];

--- a/src/BitPaySDK/Model/Payout/PayoutStatus.php
+++ b/src/BitPaySDK/Model/Payout/PayoutStatus.php
@@ -4,12 +4,12 @@ namespace BitPaySDK\Model\Payout;
 
 interface PayoutStatus
 {
-    const New        = "new";
-    const Funded     = "funded";
-    const Processing = "processing";
-    const Complete   = "complete";
-    const Failed     = "failed";
-    const Cancelled  = "cancelled";
-    const Paid       = "paid";
-    const Unpaid     = "unpaid";
+    const New        = 'new';
+    const Funded     = 'funded';
+    const Processing = 'processing';
+    const Complete   = 'complete';
+    const Failed     = 'failed';
+    const Cancelled  = 'cancelled';
+    const Paid       = 'paid';
+    const Unpaid     = 'unpaid';
 }

--- a/src/BitPaySDK/Model/Payout/RecipientReferenceMethod.php
+++ b/src/BitPaySDK/Model/Payout/RecipientReferenceMethod.php
@@ -4,7 +4,7 @@ namespace BitPaySDK\Model\Payout;
 
 interface RecipientReferenceMethod
 {
-    const EMAIL      = 1;
-    const RECIPIENT_ID         = 2;
-    const SHOPPER_ID = 3;
+    const EMAIL        = 1;
+    const RECIPIENT_ID = 2;
+    const SHOPPER_ID   = 3;
 }

--- a/src/BitPaySDK/Model/Payout/RecipientStatus.php
+++ b/src/BitPaySDK/Model/Payout/RecipientStatus.php
@@ -4,10 +4,10 @@ namespace BitPaySDK\Model\Payout;
 
 interface RecipientStatus
 {
-    const INVITED    = "invited";
-    const UNVERIFIED = "unverified";
-    const VERIFIED   = "verified";
-    const ACTIVE     = "active";
-    const PAUSED     = "paused";
-    const REMOVED    = "removed";
+    const INVITED    = 'invited';
+    const UNVERIFIED = 'unverified';
+    const VERIFIED   = 'verified';
+    const ACTIVE     = 'active';
+    const PAUSED     = 'paused';
+    const REMOVED    = 'removed';
 }

--- a/test/unit/BitPaySDK/Model/Payout/PayoutBatchTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutBatchTest.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Exceptions\BitPayException;
+use BitPaySDK\Model\Currency;
+use BitPaySDK\Model\Payout\PayoutBatch;
+use BitPaySDK\Model\Payout\PayoutInstruction;
+use BitPaySDK\Model\Payout\RecipientReferenceMethod;
+use PHPUnit\Framework\TestCase;
+
+class PayoutBatchTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $payout = $this->createClassObject();
+    $this->assertInstanceOf(PayoutBatch::class, $payout);
+  }
+
+  public function testGetToken()
+  {
+    $expectedToken = '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setToken($expectedToken);
+    $this->assertEquals($expectedToken, $payoutBatch->getToken());
+  }
+
+  public function testGetAmount()
+  {
+    $expectedAmount = 10.0;
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setAmount($expectedAmount);
+    $this->assertEquals($expectedAmount, $payoutBatch->getAmount());
+  }
+
+  public function testFormatAmount()
+  {
+    $amount = 12.3456789;
+    $expectedFormattedAmount = 12.35;
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setAmount($amount);
+    $payoutBatch->formatAmount(2);
+    $this->assertEquals($expectedFormattedAmount, $payoutBatch->getAmount());
+  }
+
+  public function testGetCurrency()
+  {
+    $expectedCurrency = Currency::USD;
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setCurrency($expectedCurrency);
+    $this->assertEquals($expectedCurrency, $payoutBatch->getCurrency());
+  }
+
+  public function testGetCurrencyException()
+  {
+    $this->expectException(BitPayException::class);
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setCurrency('ZZZ');
+  }
+
+  public function testGetEffectiveDate()
+  {
+    $expectedEffectiveDate = '2021-05-27T09:00:00.000Z';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setEffectiveDate($expectedEffectiveDate);
+    $this->assertEquals($expectedEffectiveDate, $payoutBatch->getEffectiveDate());
+  }
+
+  public function testGetInstructionsObject()
+  {
+    $expectedInstructions = [
+      new PayoutInstruction(10.0, RecipientReferenceMethod::EMAIL, 'john@doe.com')
+    ];
+    
+    $payoutBatch = new PayoutBatch(Currency::USD, $expectedInstructions, Currency::BTC);
+    $payoutBatch->setInstructions($expectedInstructions);
+    $this->assertEquals($expectedInstructions[0]->toArray(), $payoutBatch->getInstructions()[0]);
+  }
+
+  // public function testGetInstructionsArray()
+  // {
+  // }
+
+  public function testGetLedgerCurrency() {
+    $expectedLedgerCurrency = Currency::BTC;
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setLedgerCurrency($expectedLedgerCurrency);
+    $this->assertEquals($expectedLedgerCurrency, $payoutBatch->getLedgerCurrency());
+  }
+
+  public function testGetLedgerCurrencyException() {
+    $this->expectException(BitPayException::class);
+    
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setLedgerCurrency('ZZZ');
+  }
+
+  public function testGetReference()
+  {
+    $expectedReference = 'payout_20210527';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setReference($expectedReference);
+    $this->assertEquals($expectedReference, $payoutBatch->getReference());
+  }
+
+  public function testGetNotificationUrl()
+  {
+    $expectedNotificationUrl = 'http://example.com';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setNotificationUrl($expectedNotificationUrl);
+    $this->assertEquals($expectedNotificationUrl, $payoutBatch->getNotificationUrl());
+  }
+
+  public function testGetNotificationEmail()
+  {
+    $expectedNotificationEmail = 'test@test.com';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setNotificationEmail($expectedNotificationEmail);
+    $this->assertEquals($expectedNotificationEmail, $payoutBatch->getNotificationEmail());
+  }
+
+  public function testGetEmail()
+  {
+    $expectedEmail = 'test@test.com';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setEmail($expectedEmail);
+    $this->assertEquals($expectedEmail, $payoutBatch->getEmail());
+  }
+
+  public function testGetRecipientId()
+  {
+    $expectedRecipientId = 'LDxRZCGq174SF8AnQpdBPB';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setRecipientId($expectedRecipientId);
+    $this->assertEquals($expectedRecipientId, $payoutBatch->getRecipientId());
+  }
+
+  public function testGetShopperId()
+  {
+    $expectedShopperId = '7qohDf2zZnQK5Qanj8oyC2';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setShopperId($expectedShopperId);
+    $this->assertEquals($expectedShopperId, $payoutBatch->getShopperId());
+  }
+
+  public function testGetLabel()
+  {
+    $expectedLabel = 'My label';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setLabel($expectedLabel);
+    $this->assertEquals($expectedLabel, $payoutBatch->getLabel());
+  }
+
+  public function testGetMessage()
+  {
+    $expectedMessage = 'My message';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setMessage($expectedMessage);
+    $this->assertEquals($expectedMessage, $payoutBatch->getMessage());
+  }
+
+  public function testGetId()
+  {
+    $expectedId = 'abcd123';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setId($expectedId);
+    $this->assertEquals($expectedId, $payoutBatch->getId());
+  }
+
+  public function testGetAccount()
+  {
+      $expectedAccount = 'Test account';
+
+      $payoutBatch = $this->createClassObject();
+      $payoutBatch->setAccount($expectedAccount);
+      $this->assertEquals($expectedAccount, $payoutBatch->getAccount());
+  }
+
+  public function testGetStatus()
+  {
+    $expectedStatus = 'success';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setStatus($expectedStatus);
+    $this->assertEquals($expectedStatus, $payoutBatch->getStatus());
+  }
+
+  public function testGetPercentFee()
+  {
+    $expectedPercentFee = 1.0;
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setPercentFee($expectedPercentFee);
+    $this->assertEquals($expectedPercentFee, $payoutBatch->getPercentFee());
+  }
+
+  public function testGetFee()
+  {
+    $expectedFee = 1.0;
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setFee($expectedFee);
+    $this->assertEquals($expectedFee, $payoutBatch->getFee());
+  }
+
+  public function testDepositTotal()
+  {
+    $expectedDepositTotal = 1.0;
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setDepositTotal($expectedDepositTotal);
+    $this->assertEquals($expectedDepositTotal, $payoutBatch->getDepositTotal());
+  }
+
+  public function testGetBtc()
+  {
+      $expectedBtc = 1;
+
+      $payoutBatch = $this->createClassObject();
+      $payoutBatch->setBtc($expectedBtc);
+      $this->assertEquals($expectedBtc, $payoutBatch->getBtc());
+  }
+
+  public function testGetRate()
+  {
+    $expectedRate = 1.0;
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setRate($expectedRate);
+    $this->assertEquals($expectedRate, $payoutBatch->getRate());
+  }
+
+  public function testGetRequestDate()
+  {
+    $expectedRequestDate = '2021-05-27T10:47:37.834Z';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setRequestDate($expectedRequestDate);
+    $this->assertEquals($expectedRequestDate, $payoutBatch->getRequestDate());
+  }
+
+  public function testGetDateExecuted()
+  {
+    $expectedDateExecuted = '2022-01-01T10:47:37.834Z';
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setDateExecuted($expectedDateExecuted);
+    $this->assertEquals($expectedDateExecuted, $payoutBatch->getDateExecuted());
+  }
+
+  public function testGetExchangeRates()
+  {
+    $expectedExchangeRates = [
+      'BTC' => [
+        'USD' => 39390.47,
+        'GBP' => 27883.962246420004
+      ]
+    ];
+
+    $payoutBatch = $this->createClassObject();
+    $payoutBatch->setExchangeRates($expectedExchangeRates);
+    $this->assertEquals($expectedExchangeRates, $payoutBatch->getExchangeRates());
+  }
+
+  public function testToArray()
+  {
+    $payoutBatch = $this->createClassObject();
+    $this->objectSetters($payoutBatch);
+    $payoutBatchArray = $payoutBatch->toArray();
+
+    $this->assertNotNull($payoutBatchArray);
+    $this->assertIsArray($payoutBatchArray);
+
+    $this->assertArrayHasKey('currency', $payoutBatchArray);
+    $this->assertArrayHasKey('instructions', $payoutBatchArray);
+    $this->assertArrayHasKey('ledgerCurrency', $payoutBatchArray);
+    $this->assertArrayHasKey('token', $payoutBatchArray);
+    $this->assertArrayHasKey('amount', $payoutBatchArray);
+    $this->assertArrayHasKey('effectiveDate', $payoutBatchArray);
+    $this->assertArrayHasKey('reference', $payoutBatchArray);
+    $this->assertArrayHasKey('notificationURL', $payoutBatchArray);
+    $this->assertArrayHasKey('notificationEmail', $payoutBatchArray);
+    $this->assertArrayHasKey('email', $payoutBatchArray);
+    $this->assertArrayHasKey('recipientId', $payoutBatchArray);
+    $this->assertArrayHasKey('shopperId', $payoutBatchArray);
+    $this->assertArrayHasKey('label', $payoutBatchArray);
+    $this->assertArrayHasKey('message', $payoutBatchArray);
+    $this->assertArrayHasKey('id', $payoutBatchArray);
+    $this->assertArrayHasKey('account', $payoutBatchArray);
+    $this->assertArrayHasKey('supportPhone', $payoutBatchArray);
+    $this->assertArrayHasKey('status', $payoutBatchArray);
+    $this->assertArrayHasKey('percentFee', $payoutBatchArray);
+    $this->assertArrayHasKey('fee', $payoutBatchArray);
+    $this->assertArrayHasKey('depositTotal', $payoutBatchArray);
+    $this->assertArrayHasKey('btc', $payoutBatchArray);
+    $this->assertArrayHasKey('rate', $payoutBatchArray);
+    $this->assertArrayHasKey('requestDate', $payoutBatchArray);
+    $this->assertArrayHasKey('dateExecuted', $payoutBatchArray);
+    $this->assertArrayHasKey('exchangeRates', $payoutBatchArray);
+  }
+
+  public function testToArrayEmptyKey()
+  {
+    $instructions = [
+      new PayoutInstruction(10.0, RecipientReferenceMethod::EMAIL, 'john@doe.com')
+    ];
+
+    $payoutBatch = new PayoutBatch(Currency::USD, $instructions, Currency::BTC);
+    $payoutBatchArray = $payoutBatch->toArray();
+
+    $this->assertNotNull($payoutBatchArray);
+    $this->assertIsArray($payoutBatchArray);
+
+    $this->assertArrayNotHasKey('token', $payoutBatchArray);
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutBatch();
+  }
+
+  private function objectSetters(PayoutBatch $payoutBatch)
+  {
+    $instructions = [
+      new PayoutInstruction(10.0, RecipientReferenceMethod::EMAIL, 'john@doe.com')
+    ];
+
+    $payoutBatch->setCurrency(Currency::USD);
+    $payoutBatch->setInstructions($instructions);
+    $payoutBatch->setLedgerCurrency(Currency::BTC);
+    $payoutBatch->setToken('6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    $payoutBatch->setAmount(10.0);
+    $payoutBatch->setEffectiveDate('2021-05-27T09:00:00.000Z');
+    $payoutBatch->setReference('payout_20210527');
+    $payoutBatch->setNotificationURL('http://example.com');
+    $payoutBatch->setNotificationEmail('test@test.com');
+    $payoutBatch->setEmail('test@test.com');
+    $payoutBatch->setRecipientId('LDxRZCGq174SF8AnQpdBPB');
+    $payoutBatch->setShopperId('7qohDf2zZnQK5Qanj8oyC2');
+    $payoutBatch->setLabel('My label');
+    $payoutBatch->setMessage('My message');
+    $payoutBatch->setId('abcd123');
+    $payoutBatch->setAccount('Test account');
+    $payoutBatch->setSupportPhone('2155551212');
+    $payoutBatch->setStatus('success');
+    $payoutBatch->setPercentFee(1.0);
+    $payoutBatch->setFee(1.0);
+    $payoutBatch->setDepositTotal(1.0);
+    $payoutBatch->setBtc(1);
+    $payoutBatch->setRate(1.0);
+    $payoutBatch->setRequestDate('2021-05-27T10:47:37.834Z');
+    $payoutBatch->setDateExecuted('2022-01-01T10:47:37.834Z');
+    $payoutBatch->setExchangeRates([
+      'BTC' => [
+        'USD' => 39390.47,
+        'GBP' => 27883.962246420004
+      ]
+    ]);
+  }
+}

--- a/test/unit/BitPaySDK/Model/Payout/PayoutBatchTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutBatchTest.php
@@ -83,9 +83,20 @@ class PayoutBatchTest extends TestCase
     $this->assertEquals($expectedInstructions[0]->toArray(), $payoutBatch->getInstructions()[0]);
   }
 
-  // public function testGetInstructionsArray()
-  // {
-  // }
+  public function testGetInstructionsArray()
+  {
+
+    $expectedInstructions = [
+      [
+        'amount' => 10.0,
+        'email' => 'john@doe.com'
+      ]
+    ];
+    
+    $payoutBatch = new PayoutBatch(Currency::USD, [], Currency::BTC);
+    $payoutBatch->setInstructions($expectedInstructions);
+    $this->assertEquals($expectedInstructions, $payoutBatch->getInstructions());
+  }
 
   public function testGetLedgerCurrency() {
     $expectedLedgerCurrency = Currency::BTC;

--- a/test/unit/BitPaySDK/Model/Payout/PayoutBatchTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutBatchTest.php
@@ -313,6 +313,35 @@ class PayoutBatchTest extends TestCase
     $this->assertArrayHasKey('requestDate', $payoutBatchArray);
     $this->assertArrayHasKey('dateExecuted', $payoutBatchArray);
     $this->assertArrayHasKey('exchangeRates', $payoutBatchArray);
+
+    $this->assertEquals($payoutBatchArray['currency'], Currency::USD);
+    $this->assertEquals($payoutBatchArray['instructions'][0]['amount'], 10.0);
+    $this->assertEquals($payoutBatchArray['instructions'][0]['email'], 'john@doe.com');
+    $this->assertEquals($payoutBatchArray['ledgerCurrency'], Currency::BTC);
+    $this->assertEquals($payoutBatchArray['token'], '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    $this->assertEquals($payoutBatchArray['amount'], 10.0);
+    $this->assertEquals($payoutBatchArray['effectiveDate'], '2021-05-27T09:00:00.000Z');
+    $this->assertEquals($payoutBatchArray['reference'], 'payout_20210527');
+    $this->assertEquals($payoutBatchArray['notificationURL'], 'http://example.com');
+    $this->assertEquals($payoutBatchArray['notificationEmail'], 'test@test.com');
+    $this->assertEquals($payoutBatchArray['email'], 'test@test.com');
+    $this->assertEquals($payoutBatchArray['recipientId'], 'LDxRZCGq174SF8AnQpdBPB');
+    $this->assertEquals($payoutBatchArray['shopperId'], '7qohDf2zZnQK5Qanj8oyC2');
+    $this->assertEquals($payoutBatchArray['label'], 'My label');
+    $this->assertEquals($payoutBatchArray['message'], 'My message');
+    $this->assertEquals($payoutBatchArray['id'], 'abcd123');
+    $this->assertEquals($payoutBatchArray['account'], 'Test account');
+    $this->assertEquals($payoutBatchArray['supportPhone'], '2155551212');
+    $this->assertEquals($payoutBatchArray['status'], 'success');
+    $this->assertEquals($payoutBatchArray['percentFee'], 1.0);
+    $this->assertEquals($payoutBatchArray['fee'], 1.0);
+    $this->assertEquals($payoutBatchArray['depositTotal'], 1.0);
+    $this->assertEquals($payoutBatchArray['btc'], 1);
+    $this->assertEquals($payoutBatchArray['rate'], 1);
+    $this->assertEquals($payoutBatchArray['requestDate'], '2021-05-27T10:47:37.834Z');
+    $this->assertEquals($payoutBatchArray['dateExecuted'], '2022-01-01T10:47:37.834Z');
+    $this->assertEquals($payoutBatchArray['exchangeRates']['BTC']['USD'], 39390.47);
+    $this->assertEquals($payoutBatchArray['exchangeRates']['BTC']['GBP'], 27883.962246420004);
   }
 
   public function testToArrayEmptyKey()

--- a/test/unit/BitPaySDK/Model/Payout/PayoutInstructionTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutInstructionTest.php
@@ -6,6 +6,7 @@ use BitPaySDK\Exceptions\BitPayException;
 use BitPaySDK\Exceptions\PayoutBatchCreationException;
 use BitPaySDK\Model\Payout\PayoutInstruction;
 use BitPaySDK\Model\Payout\PayoutInstructionBtcSummary;
+use BitPaySDK\Model\Payout\PayoutInstructionTransaction;
 use BitPaySDK\Model\Payout\RecipientReferenceMethod;
 use PHPUnit\Framework\TestCase;
 
@@ -119,13 +120,13 @@ class PayoutInstructionTest extends TestCase
 
   public function testGetTransactions()
   {
-    $expectedTransactions = [
-      [
-        'txid' => 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057',
-        'amount' => 0.000254,
-        'date' => '2021-05-27T11:04:23.155Z'
-      ]
-    ];
+    $expectedTransactions = [];
+
+    $transaction = new PayoutInstructionTransaction();
+    $transaction->setTxid('db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057');
+    $transaction->setAmount(0.000254);
+    $transaction->setDate('2021-05-27T11:04:23.155Z');
+    array_push($expectedTransactions, $transaction);
 
     $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
     $payoutInstruction->setTransactions($expectedTransactions);
@@ -133,7 +134,7 @@ class PayoutInstructionTest extends TestCase
     $this->assertEquals($expectedTransactions, $payoutInstruction->getTransactions());
   }
 
-  public function testgetStatus()
+  public function testGetStatus()
   {
     $expectedStatus = 'success';
     
@@ -176,8 +177,26 @@ class PayoutInstructionTest extends TestCase
     $this->assertEquals($payoutInstructionArray['status'], 'success');
   }
 
+  public function testToArrayEmptyKey()
+  {
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $payoutInstructionArray = $payoutInstruction->toArray();
+
+    $this->assertNotNull($payoutInstructionArray);
+    $this->assertIsArray($payoutInstructionArray);
+
+    $this->assertArrayNotHasKey('transactions', $payoutInstructionArray);
+  }
+
   private function objectSetters(PayoutInstruction $payoutInstruction)
   {
+    $transactions = [];
+    $transaction = new PayoutInstructionTransaction();
+    $transaction->setTxid('db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057');
+    $transaction->setAmount(0.000254);
+    $transaction->setDate('2021-05-27T11:04:23.155Z');
+    array_push($transactions, $transaction->toArray());
+
     $payoutInstruction->setAmount(10.0);
     $payoutInstruction->setEmail('jane@doe.com');
     $payoutInstruction->setRecipientId('abcd123');
@@ -185,13 +204,7 @@ class PayoutInstructionTest extends TestCase
     $payoutInstruction->setLabel('My label');
     $payoutInstruction->setId('ijkl789');
     $payoutInstruction->setBtc(new PayoutInstructionBtcSummary(1.23, 4.56));
-    $payoutInstruction->setTransactions([
-      [
-        'txid' => 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057',
-        'amount' => 0.000254,
-        'date' => '2021-05-27T11:04:23.155Z'
-      ]
-    ]);
+    $payoutInstruction->setTransactions($transactions);
     $payoutInstruction->setStatus('success');
   }
 }

--- a/test/unit/BitPaySDK/Model/Payout/PayoutInstructionTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutInstructionTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Exceptions\BitPayException;
+use BitPaySDK\Exceptions\PayoutBatchCreationException;
+use BitPaySDK\Model\Payout\PayoutInstruction;
+use BitPaySDK\Model\Payout\PayoutInstructionBtcSummary;
+use BitPaySDK\Model\Payout\RecipientReferenceMethod;
+use PHPUnit\Framework\TestCase;
+
+class PayoutInstructionTest extends TestCase
+{
+  public function testConstructEmail()
+  {
+    $expectedEmail = 'john@doe.com';
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, $expectedEmail);
+    $this->assertEquals($expectedEmail, $payoutInstruction->getEmail());
+  }
+
+  public function testConstructRecipientId()
+  {
+    $expectedRecipientId = 'abcd123';
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::RECIPIENT_ID, $expectedRecipientId);
+    $this->assertEquals($expectedRecipientId, $payoutInstruction->getRecipientId());
+  }
+
+  public function testConstructShopperId()
+  {
+    $expectedShopperId = 'abcd123';
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::SHOPPER_ID, $expectedShopperId);
+    $this->assertEquals($expectedShopperId, $payoutInstruction->getShopperId());
+  }
+
+  public function testConstructInvalid()
+  {
+    $this->expectException(PayoutBatchCreationException::class);
+    new PayoutInstruction(5.0, 999, 'abcd123');
+  }
+
+  public function testGetAmount()
+  {
+    $expectedAmount = 10.0;
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $payoutInstruction->setAmount($expectedAmount);
+
+    $this->assertEquals($expectedAmount, $payoutInstruction->getAmount());
+  }
+
+  public function testGetAmountLessThanFive()
+  {
+    $this->expectException(BitPayException::class);
+    new PayoutInstruction(1.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+  }
+
+  public function testGetEmail()
+  {
+    $expectedEmail = 'jane@doe.com';
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $payoutInstruction->setEmail($expectedEmail);
+
+    $this->assertEquals($expectedEmail, $payoutInstruction->getEmail());
+  }
+
+  public function testGetRecipientId()
+  {
+    $expectedRecipientId = 'efgh456';
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::RECIPIENT_ID, 'abcd123');
+    $payoutInstruction->setRecipientId($expectedRecipientId);
+
+    $this->assertEquals($expectedRecipientId, $payoutInstruction->getRecipientId());
+  }
+
+  public function testGetShopperId()
+  {
+    $expectedShopperId = 'efgh456';
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::RECIPIENT_ID, 'abcd123');
+    $payoutInstruction->setShopperId($expectedShopperId);
+
+    $this->assertEquals($expectedShopperId, $payoutInstruction->getShopperId());
+  }
+
+  public function testGetLabel()
+  {
+    $expectedLabel = 'My label';
+    
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $payoutInstruction->setLabel($expectedLabel);
+
+    $this->assertEquals($expectedLabel, $payoutInstruction->getLabel());
+  }
+
+  public function testGetId()
+  {
+    $expectedId = 'id_1234';
+    
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $payoutInstruction->setId($expectedId);
+
+    $this->assertEquals($expectedId, $payoutInstruction->getId());
+  }
+
+  public function testGetBtc()
+  {
+    $expectedPayoutInstructionBtcSummary = new PayoutInstructionBtcSummary(1.23, 4.56);
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $payoutInstruction->setBtc($expectedPayoutInstructionBtcSummary);
+
+    $this->assertEquals($expectedPayoutInstructionBtcSummary->toArray(), $payoutInstruction->getBtc($expectedPayoutInstructionBtcSummary));
+  }
+
+  public function testGetTransactions()
+  {
+    $expectedTransactions = [
+      [
+        'txid' => 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057',
+        'amount' => 0.000254,
+        'date' => '2021-05-27T11:04:23.155Z'
+      ]
+    ];
+
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $payoutInstruction->setTransactions($expectedTransactions);
+
+    $this->assertEquals($expectedTransactions, $payoutInstruction->getTransactions());
+  }
+
+  public function testgetStatus()
+  {
+    $expectedStatus = 'success';
+    
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $payoutInstruction->setStatus($expectedStatus);
+
+    $this->assertEquals($expectedStatus, $payoutInstruction->getStatus());
+  }
+
+  public function testToArray()
+  {
+    $payoutInstruction = new PayoutInstruction(5.0, RecipientReferenceMethod::EMAIL, 'john@doe.com');
+    $this->objectSetters($payoutInstruction);
+    $payoutInstructionArray = $payoutInstruction->toArray();
+
+    $this->assertNotNull($payoutInstructionArray);
+    $this->assertIsArray($payoutInstructionArray);
+
+    $this->assertArrayHasKey('amount', $payoutInstructionArray);
+    $this->assertArrayHasKey('email', $payoutInstructionArray);
+    $this->assertArrayHasKey('recipientId', $payoutInstructionArray);
+    $this->assertArrayHasKey('shopperId', $payoutInstructionArray);
+    $this->assertArrayHasKey('label', $payoutInstructionArray);
+    $this->assertArrayHasKey('id', $payoutInstructionArray);
+    $this->assertArrayHasKey('btc', $payoutInstructionArray);
+    $this->assertArrayHasKey('transactions', $payoutInstructionArray);
+    $this->assertArrayHasKey('status', $payoutInstructionArray);
+
+    $this->assertEquals($payoutInstructionArray['amount'], 10.0);
+    $this->assertEquals($payoutInstructionArray['email'], 'jane@doe.com');
+    $this->assertEquals($payoutInstructionArray['recipientId'], 'abcd123');
+    $this->assertEquals($payoutInstructionArray['shopperId'], 'efgh456');
+    $this->assertEquals($payoutInstructionArray['label'], 'My label');
+    $this->assertEquals($payoutInstructionArray['id'], 'ijkl789');
+    $this->assertEquals($payoutInstructionArray['btc']['paid'], 1.23);
+    $this->assertEquals($payoutInstructionArray['btc']['unpaid'], 4.56);
+    $this->assertEquals($payoutInstructionArray['transactions'][0]['txid'], 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057');
+    $this->assertEquals($payoutInstructionArray['transactions'][0]['amount'], 0.000254);
+    $this->assertEquals($payoutInstructionArray['transactions'][0]['date'], '2021-05-27T11:04:23.155Z');
+    $this->assertEquals($payoutInstructionArray['status'], 'success');
+  }
+
+  private function objectSetters(PayoutInstruction $payoutInstruction)
+  {
+    $payoutInstruction->setAmount(10.0);
+    $payoutInstruction->setEmail('jane@doe.com');
+    $payoutInstruction->setRecipientId('abcd123');
+    $payoutInstruction->setShopperId('efgh456');
+    $payoutInstruction->setLabel('My label');
+    $payoutInstruction->setId('ijkl789');
+    $payoutInstruction->setBtc(new PayoutInstructionBtcSummary(1.23, 4.56));
+    $payoutInstruction->setTransactions([
+      [
+        'txid' => 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057',
+        'amount' => 0.000254,
+        'date' => '2021-05-27T11:04:23.155Z'
+      ]
+    ]);
+    $payoutInstruction->setStatus('success');
+  }
+}

--- a/test/unit/BitPaySDK/Model/Payout/PayoutInstructionTransactionTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutInstructionTransactionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Model\Payout\PayoutInstructionTransaction;
+use PHPUnit\Framework\TestCase;
+
+class PayoutInstructionTransactionTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $payoutInstructionTransaction = $this->createClassObject();
+    $this->assertInstanceOf(PayoutInstructionTransaction::class, $payoutInstructionTransaction);
+  }
+
+  public function testGetTxid()
+  {
+    $expectedTxid = 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057';
+    
+    $payoutInstructionTransaction = $this->createClassObject();
+    $payoutInstructionTransaction->setTxId($expectedTxid);
+
+    $this->assertEquals($expectedTxid, $payoutInstructionTransaction->getTxid());
+  }
+
+  public function testGetAmount()
+  {
+    $expectedAmount = 0.000254;
+
+    $payoutInstructionTransaction = $this->createClassObject();
+    $payoutInstructionTransaction->setAmount($expectedAmount);
+
+    $this->assertEquals($expectedAmount, $payoutInstructionTransaction->getAmount());
+  }
+
+  public function testGetDate()
+  {
+    $expectedDate = '2021-05-27T11:04:23.155Z';
+
+    $payoutInstructionTransaction = $this->createClassObject();
+    $payoutInstructionTransaction->setDate($expectedDate);
+
+    $this->assertEquals($expectedDate, $payoutInstructionTransaction->getDate());
+  }
+
+  public function testToArray()
+  {
+    $payoutInstructionTransaction = $this->createClassObject();
+    $payoutInstructionTransaction->setTxid('db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057');
+    $payoutInstructionTransaction->setAmount(0.000254);
+    $payoutInstructionTransaction->setDate('2021-05-27T11:04:23.155Z');
+    $payoutInstructionTransactionArray = $payoutInstructionTransaction->toArray();
+
+    $this->assertNotNull($payoutInstructionTransactionArray);
+    $this->assertIsArray($payoutInstructionTransactionArray);
+
+    $this->assertArrayHasKey('txid', $payoutInstructionTransactionArray);
+    $this->assertArrayHasKey('amount', $payoutInstructionTransactionArray);
+    $this->assertArrayHasKey('date', $payoutInstructionTransactionArray);
+
+    $this->assertEquals($payoutInstructionTransactionArray['txid'], 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057');
+    $this->assertEquals($payoutInstructionTransactionArray['amount'], 0.000254);
+    $this->assertEquals($payoutInstructionTransactionArray['date'], '2021-05-27T11:04:23.155Z');
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutInstructionTransaction();
+  }
+}

--- a/test/unit/BitPaySDK/Model/Payout/PayoutInstructionsBtcSummaryTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutInstructionsBtcSummaryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Model\Payout\PayoutInstructionBtcSummary;
+use PHPUnit\Framework\TestCase;
+
+class PayoutInstructionsBtcSummaryTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $payout = $this->createClassObject();
+    $this->assertInstanceOf(PayoutInstructionBtcSummary::class, $payout);
+  }
+
+  public function testGetPaid()
+  {
+    $expectedPaid = 1.23;
+
+    $payoutInstructionBtcSummary = $this->createClassObject();
+    $this->assertEquals($expectedPaid, $payoutInstructionBtcSummary->getPaid());
+  }
+
+  public function testGetUnPaid()
+  {
+    $expectedUnpaid = 4.56;
+
+    $payoutInstructionBtcSummary = $this->createClassObject();
+    $this->assertEquals($expectedUnpaid, $payoutInstructionBtcSummary->getUnpaid());
+  }
+
+  public function testToArray()
+  {
+    $expectedPaid = 1.23;
+    $expectedUnpaid = 4.56;
+
+    $payoutInstructionBtcSummary = $this->createClassObject();
+    $payoutInstructionBtcSummaryArray = $payoutInstructionBtcSummary->toArray();
+
+    $this->assertNotNull($payoutInstructionBtcSummaryArray);
+    $this->assertIsArray($payoutInstructionBtcSummaryArray);
+
+    $this->assertArrayHasKey('paid', $payoutInstructionBtcSummaryArray);
+    $this->assertArrayHasKey('unpaid', $payoutInstructionBtcSummaryArray);
+  }
+
+  private function createClassObject()
+  {
+    $paid = 1.23;
+    $unpaid = 4.56;
+    return new PayoutInstructionBtcSummary($paid, $unpaid);
+  }
+}

--- a/test/unit/BitPaySDK/Model/Payout/PayoutInstructionsBtcSummaryTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutInstructionsBtcSummaryTest.php
@@ -31,9 +31,6 @@ class PayoutInstructionsBtcSummaryTest extends TestCase
 
   public function testToArray()
   {
-    $expectedPaid = 1.23;
-    $expectedUnpaid = 4.56;
-
     $payoutInstructionBtcSummary = $this->createClassObject();
     $payoutInstructionBtcSummaryArray = $payoutInstructionBtcSummary->toArray();
 
@@ -42,6 +39,9 @@ class PayoutInstructionsBtcSummaryTest extends TestCase
 
     $this->assertArrayHasKey('paid', $payoutInstructionBtcSummaryArray);
     $this->assertArrayHasKey('unpaid', $payoutInstructionBtcSummaryArray);
+
+    $this->assertEquals($payoutInstructionBtcSummaryArray['paid'], 1.23);
+    $this->assertEquals($payoutInstructionBtcSummaryArray['unpaid'], 4.56);
   }
 
   private function createClassObject()

--- a/test/unit/BitPaySDK/Model/Payout/PayoutReceivedInfoAddressTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutReceivedInfoAddressTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Model\Payout\PayoutReceivedInfoAddress;
+use PHPUnit\Framework\TestCase;
+
+class PayoutReceivedInfoAddressTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $this->assertInstanceOf(PayoutReceivedInfoAddress::class, $payoutReceivedInfoAddress);
+  }
+
+  public function testGetAddress1()
+  {
+    $expectedAddress1 = '123 Main St.';
+    
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $payoutReceivedInfoAddress->setAddress1($expectedAddress1);
+    $this->assertEquals($expectedAddress1, $payoutReceivedInfoAddress->getAddress1());
+  }
+
+  public function testGetAddress2()
+  {
+    $expectedAddress2 = '#4';
+    
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $payoutReceivedInfoAddress->setAddress2($expectedAddress2);
+    $this->assertEquals($expectedAddress2, $payoutReceivedInfoAddress->getAddress2());
+  }
+
+  public function testGetLocality()
+  {
+    $expectedLocality = 'Locality Name';
+    
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $payoutReceivedInfoAddress->setLocality($expectedLocality);
+    $this->assertEquals($expectedLocality, $payoutReceivedInfoAddress->getLocality());
+  }
+
+  public function testGetRegion()
+  {
+    $expectedRegion = 'Region Name';
+    
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $payoutReceivedInfoAddress->setRegion($expectedRegion);
+    $this->assertEquals($expectedRegion, $payoutReceivedInfoAddress->getRegion());
+  }
+
+  public function testGetPostalCode()
+  {
+    $expectedPostalCode = '00000';
+    
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $payoutReceivedInfoAddress->setPostalCode($expectedPostalCode);
+    $this->assertEquals($expectedPostalCode, $payoutReceivedInfoAddress->getPostalCode());
+  }
+
+  public function testGetCountry()
+  {
+    $expectedCountry = 'US';
+    
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $payoutReceivedInfoAddress->setCountry($expectedCountry);
+    $this->assertEquals($expectedCountry, $payoutReceivedInfoAddress->getCountry());
+  }
+
+  public function testToArray()
+  {
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $payoutReceivedInfoAddress->setAddress1('123 Main St.');
+    $payoutReceivedInfoAddress->setAddress2('#4');
+    $payoutReceivedInfoAddress->setLocality('Locality Name');
+    $payoutReceivedInfoAddress->setRegion('Region Name');
+    $payoutReceivedInfoAddress->setPostalCode('00000');
+    $payoutReceivedInfoAddress->setCountry('US');
+    $payoutReceivedInfoAddressArray = $payoutReceivedInfoAddress->toArray();
+
+    $this->assertNotNull($payoutReceivedInfoAddressArray);
+    $this->assertIsArray($payoutReceivedInfoAddressArray);
+
+    $this->assertArrayHasKey('address1', $payoutReceivedInfoAddressArray);
+    $this->assertArrayHasKey('address2', $payoutReceivedInfoAddressArray);
+    $this->assertArrayHasKey('locality', $payoutReceivedInfoAddressArray);
+    $this->assertArrayHasKey('region', $payoutReceivedInfoAddressArray);
+    $this->assertArrayHasKey('postalCode', $payoutReceivedInfoAddressArray);
+    $this->assertArrayHasKey('country', $payoutReceivedInfoAddressArray);
+
+    $this->assertEquals($payoutReceivedInfoAddressArray['address1'], '123 Main St.');
+    $this->assertEquals($payoutReceivedInfoAddressArray['address2'], '#4');
+    $this->assertEquals($payoutReceivedInfoAddressArray['locality'], 'Locality Name');
+    $this->assertEquals($payoutReceivedInfoAddressArray['region'], 'Region Name');
+    $this->assertEquals($payoutReceivedInfoAddressArray['postalCode'], '00000');
+    $this->assertEquals($payoutReceivedInfoAddressArray['country'], 'US');
+  }
+
+  public function testToArrayEmptyKey()
+  {
+    $payoutReceivedInfoAddress = $this->createClassObject();
+    $payoutReceivedInfoAddressArray = $payoutReceivedInfoAddress->toArray();
+
+    $this->assertArrayNotHasKey('address1', $payoutReceivedInfoAddressArray);
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutReceivedInfoAddress();
+  }
+}

--- a/test/unit/BitPaySDK/Model/Payout/PayoutReceivedInfoTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutReceivedInfoTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Model\Payout\PayoutReceivedInfo;
+use BitPaySDK\Model\Payout\PayoutReceivedInfoAddress;
+use PHPUnit\Framework\TestCase;
+
+class PayoutReceivedInfoTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $payoutReceivedInfo = $this->createClassObject();
+    $this->assertInstanceOf(PayoutReceivedInfo::class, $payoutReceivedInfo);
+  }
+
+  public function testGetName()
+  {
+    $expectedName = 'John Doe';
+
+    $payoutReceivedInfo = $this->createClassObject();
+    $payoutReceivedInfo->setName($expectedName);
+    $this->assertEquals($expectedName, $payoutReceivedInfo->getName());
+  }
+
+  public function testGetEmail()
+  {
+    $expectedEmail = 'john@doe.com';
+
+    $payoutReceivedInfo = $this->createClassObject();
+    $payoutReceivedInfo->setEmail($expectedEmail);
+    $this->assertEquals($expectedEmail, $payoutReceivedInfo->getEmail());
+  }
+
+  public function testGetAddress()
+  {
+    $expectedAddress = new PayoutReceivedInfoAddress();
+    $expectedAddress->setAddress1('123 Main St.');
+    $expectedAddress->setAddress2('#4');
+    $expectedAddress->setLocality('Locality Name');
+    $expectedAddress->setRegion('Region Name');
+    $expectedAddress->setPostalCode('00000');
+    $expectedAddress->setCountry('US');
+
+    $payoutReceivedInfo = $this->createClassObject();
+    $payoutReceivedInfo->setAddress($expectedAddress);
+    $this->assertEquals($expectedAddress, $payoutReceivedInfo->getAddress());
+  }
+
+  public function testToArray()
+  {
+    $payoutReceivedInfo = $this->createClassObject();
+    $this->objectSetters($payoutReceivedInfo);
+    $payoutReceivedInfoArray = $payoutReceivedInfo->toArray();
+
+    $this->assertNotNull($payoutReceivedInfoArray);
+    $this->assertIsArray($payoutReceivedInfoArray);
+
+    $this->assertArrayHasKey('name', $payoutReceivedInfoArray);
+    $this->assertArrayHasKey('email', $payoutReceivedInfoArray);
+    $this->assertArrayHasKey('address', $payoutReceivedInfoArray);
+
+    $this->assertEquals($payoutReceivedInfoArray['name'], 'John Doe');
+    $this->assertEquals($payoutReceivedInfoArray['email'], 'john@doe.com');
+    $this->assertEquals($payoutReceivedInfoArray['address']['address1'], '123 Main St.');
+    $this->assertEquals($payoutReceivedInfoArray['address']['address2'], '#4');
+    $this->assertEquals($payoutReceivedInfoArray['address']['locality'], 'Locality Name');
+    $this->assertEquals($payoutReceivedInfoArray['address']['region'], 'Region Name');
+    $this->assertEquals($payoutReceivedInfoArray['address']['postalCode'], '00000');
+    $this->assertEquals($payoutReceivedInfoArray['address']['country'], 'US');
+  }
+
+  public function testToArrayEmptyKey()
+  {
+    $address = new PayoutReceivedInfoAddress();
+    $address->setAddress1('123 Main St.');
+    $address->setAddress2('#4');
+    $address->setLocality('Locality Name');
+    $address->setRegion('Region Name');
+    $address->setPostalCode('00000');
+    $address->setCountry('US');
+
+    $payoutReceivedInfo = $this->createClassObject();
+    $payoutReceivedInfo->setAddress($address);
+    $payoutReceivedInfoArray = $payoutReceivedInfo->toArray();
+    
+    $this->assertArrayNotHasKey('name', $payoutReceivedInfoArray);
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutReceivedInfo();
+  }
+
+  private function objectSetters(PayoutReceivedInfo $payoutReceivedInfo)
+  {
+    $address = new PayoutReceivedInfoAddress();
+    $address->setAddress1('123 Main St.');
+    $address->setAddress2('#4');
+    $address->setLocality('Locality Name');
+    $address->setRegion('Region Name');
+    $address->setPostalCode('00000');
+    $address->setCountry('US');
+
+    $payoutReceivedInfo->setName('John Doe');
+    $payoutReceivedInfo->setEmail('john@doe.com');
+    $payoutReceivedInfo->setAddress($address);
+  }
+}

--- a/test/unit/BitPaySDK/Model/Payout/PayoutRecipientTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutRecipientTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Model\Payout\PayoutRecipient;
+use PHPUnit\Framework\TestCase;
+
+class PayoutRecipientTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $payoutRecipient = $this->createClassObject();
+    $this->assertInstanceOf(PayoutRecipient::class, $payoutRecipient);
+  }
+
+  public function testGetEmail()
+  {
+    $expectedEmail = 'john@doe.com';
+    
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipient->setEmail($expectedEmail);
+
+    $this->assertEquals($expectedEmail, $payoutRecipient->getEmail());
+  }
+
+  public function testGetLabel()
+  {
+    $expectedLabel = 'My Label';
+    
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipient->setLabel($expectedLabel);
+
+    $this->assertEquals($expectedLabel, $payoutRecipient->getLabel());
+  }
+
+  public function testGetNotificationURL()
+  {
+    $expectedNotificationURL = 'https://www.example.com';
+    
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipient->setNotificationURL($expectedNotificationURL);
+
+    $this->assertEquals($expectedNotificationURL, $payoutRecipient->getNotificationURL());
+  }
+
+  public function testGetStatus()
+  {
+    $expectedStatus = 'success';
+    
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipient->setStatus($expectedStatus);
+
+    $this->assertEquals($expectedStatus, $payoutRecipient->getStatus());
+  }
+
+  public function testGetId()
+  {
+    $expectedId = 'abcd123';
+    
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipient->setId($expectedId);
+
+    $this->assertEquals($expectedId, $payoutRecipient->getId());
+  }
+
+  public function testGetShopperId()
+  {
+    $expectedShopperId = 'efgh456';
+    
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipient->setShopperId($expectedShopperId);
+
+    $this->assertEquals($expectedShopperId, $payoutRecipient->getShopperId());
+  }
+
+  public function testGetToken()
+  {
+    $expectedToken = '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL';
+    
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipient->setToken($expectedToken);
+
+    $this->assertEquals($expectedToken, $payoutRecipient->getToken());
+  }
+
+  public function testToArray()
+  {
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipient->setEmail('john@doe.com');
+    $payoutRecipient->setLabel('My Label');
+    $payoutRecipient->setNotificationURL('https://www.example.com');
+    $payoutRecipient->setStatus('success');
+    $payoutRecipient->setId('abcd123');
+    $payoutRecipient->setShopperId('efgh456');
+    $payoutRecipient->setToken('6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    $payoutRecipientArray = $payoutRecipient->toArray();
+
+    $this->assertNotNull($payoutRecipientArray);
+    $this->assertIsArray($payoutRecipientArray);
+
+    $this->assertArrayHasKey('email', $payoutRecipientArray);
+    $this->assertArrayHasKey('label', $payoutRecipientArray);
+    $this->assertArrayHasKey('notificationURL', $payoutRecipientArray);
+    $this->assertArrayHasKey('status', $payoutRecipientArray);
+    $this->assertArrayHasKey('id', $payoutRecipientArray);
+    $this->assertArrayHasKey('shopperId', $payoutRecipientArray);
+    $this->assertArrayHasKey('token', $payoutRecipientArray);
+
+    $this->assertEquals($payoutRecipientArray['email'], 'john@doe.com');
+    $this->assertEquals($payoutRecipientArray['label'], 'My Label');
+    $this->assertEquals($payoutRecipientArray['notificationURL'], 'https://www.example.com');
+    $this->assertEquals($payoutRecipientArray['status'], 'success');
+    $this->assertEquals($payoutRecipientArray['id'], 'abcd123');
+    $this->assertEquals($payoutRecipientArray['shopperId'], 'efgh456');
+    $this->assertEquals($payoutRecipientArray['token'], '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+  }
+
+  public function testToArrayEmptyKey()
+  {
+    $payoutRecipient = $this->createClassObject();
+    $payoutRecipientArray = $payoutRecipient->toArray();
+
+    $this->assertArrayNotHasKey('email', $payoutRecipientArray);
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutRecipient();
+  }
+}

--- a/test/unit/BitPaySDK/Model/Payout/PayoutRecipientsTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutRecipientsTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Model\Payout\PayoutRecipient;
+use BitPaySDK\Model\Payout\PayoutRecipients;
+use PHPUnit\Framework\TestCase;
+
+class PayoutRecipientsTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $payoutRecipients = $this->createClassObject();
+    $this->assertInstanceOf(PayoutRecipients::class, $payoutRecipients);
+  }
+
+  public function testGetGuid()
+  {
+    $expectedGuid = 'cd47864e-374b-4a92-8592-4357fcbc6a89';
+
+    $payoutRecipients = $this->createClassObject();
+    $payoutRecipients->setGuid($expectedGuid);
+    $this->assertEquals($expectedGuid, $payoutRecipients->getGuid());
+  }
+
+  public function testGetRecipientsObject()
+  {
+    $expectedPayoutRecipients = [];
+    $payoutRecipient = new PayoutRecipient();
+    $payoutRecipient->setEmail('john@doe.com');
+    $payoutRecipient->setLabel('My Label');
+    $payoutRecipient->setNotificationURL('https://www.example.com');
+    $payoutRecipient->setStatus('success');
+    $payoutRecipient->setId('abcd123');
+    $payoutRecipient->setShopperId('efgh456');
+    $payoutRecipient->setToken('6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    array_push($expectedPayoutRecipients, $payoutRecipient);
+
+    $payoutRecipients = $this->createClassObject();
+    $payoutRecipients->setRecipients($expectedPayoutRecipients);
+    $this->assertEquals($expectedPayoutRecipients[0]->toArray(), $payoutRecipients->getRecipients()[0]);
+  }
+
+  public function testGetRecipientsArray()
+  {
+    $expectedPayoutRecipients = [
+      [
+        'email' => 'john@doe.com',
+        'label' => 'My Label',
+        'notificationURL' => 'https://www.example.com',
+        'status' => 'success',
+        'id' => 'abcd123',
+        'shopperId' => 'efgh456',
+        'payoutRecipient' => '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL'
+      ]
+    ];
+
+    $payoutRecipients = $this->createClassObject();
+    $payoutRecipients->setRecipients($expectedPayoutRecipients);
+    $this->assertEquals($expectedPayoutRecipients, $payoutRecipients->getRecipients());
+  }
+
+  public function testGetToken()
+  {
+    $expectedToken = '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL';
+
+    $payoutRecipients = $this->createClassObject();
+    $payoutRecipients->setToken($expectedToken);
+    $this->assertEquals($expectedToken, $payoutRecipients->getToken());
+  }
+
+  public function testToArray()
+  {
+    $expectedPayoutRecipients = [];
+    $payoutRecipient = new PayoutRecipient();
+    $payoutRecipient->setEmail('john@doe.com');
+    $payoutRecipient->setLabel('My Label');
+    $payoutRecipient->setNotificationURL('https://www.example.com');
+    $payoutRecipient->setStatus('success');
+    $payoutRecipient->setId('abcd123');
+    $payoutRecipient->setShopperId('efgh456');
+    $payoutRecipient->setToken('6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    array_push($expectedPayoutRecipients, $payoutRecipient);
+
+    $payoutRecipients = $this->createClassObject();
+    $payoutRecipients->setGuid('cd47864e-374b-4a92-8592-4357fcbc6a89');
+    $payoutRecipients->setRecipients($expectedPayoutRecipients);
+    $payoutRecipients->setToken('6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    $payoutRecipientsArray = $payoutRecipients->toArray();
+
+    $this->assertNotNull($payoutRecipientsArray);
+    $this->assertIsArray($payoutRecipientsArray);
+
+    $this->assertArrayHasKey('guid', $payoutRecipientsArray);
+    $this->assertArrayHasKey('recipients', $payoutRecipientsArray);
+    $this->assertArrayHasKey('token', $payoutRecipientsArray);
+
+    $this->assertEquals($payoutRecipientsArray['guid'], 'cd47864e-374b-4a92-8592-4357fcbc6a89');
+    $this->assertEquals($payoutRecipientsArray['recipients'][0]['email'], 'john@doe.com');
+    $this->assertEquals($payoutRecipientsArray['recipients'][0]['label'], 'My Label');
+    $this->assertEquals($payoutRecipientsArray['recipients'][0]['notificationURL'], 'https://www.example.com');
+    $this->assertEquals($payoutRecipientsArray['recipients'][0]['status'], 'success');
+    $this->assertEquals($payoutRecipientsArray['recipients'][0]['id'], 'abcd123');
+    $this->assertEquals($payoutRecipientsArray['recipients'][0]['shopperId'], 'efgh456');
+    $this->assertEquals($payoutRecipientsArray['recipients'][0]['token'], '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    $this->assertEquals($payoutRecipientsArray['token'], '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+  }
+
+  public function testToArrayEmptyKey()
+  {
+    $payoutRecipients = $this->createClassObject();
+    $payoutRecipientsArray = $payoutRecipients->toArray();
+    $this->assertArrayNotHasKey('guid', $payoutRecipientsArray);
+  }
+
+  private function createClassObject()
+  {
+    return new PayoutRecipients();
+  }
+}

--- a/test/unit/BitPaySDK/Model/Payout/PayoutTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutTest.php
@@ -25,7 +25,7 @@ class PayoutTest extends TestCase
     $this->assertEquals($expectedToken, $payout->getToken());
   }
 
-  public function testAmount()
+  public function testGetAmount()
   {
     $expectedAmount = 10.0;
 

--- a/test/unit/BitPaySDK/Model/Payout/PayoutTest.php
+++ b/test/unit/BitPaySDK/Model/Payout/PayoutTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace BitPaySDK\Test\Model\Payout;
+
+use BitPaySDK\Exceptions\BitPayException;
+use BitPaySDK\Model\Currency;
+use BitPaySDK\Model\Payout\Payout;
+use BitPaySDK\Model\Payout\PayoutTransaction;
+use PHPUnit\Framework\TestCase;
+
+class PayoutTest extends TestCase
+{
+  public function testInstanceOf()
+  {
+    $payout = $this->createClassObject();
+    $this->assertInstanceOf(Payout::class, $payout);
+  }
+
+  public function testGetToken()
+  {
+    $expectedToken = '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL';
+
+    $payout = $this->createClassObject();
+    $payout->setToken($expectedToken);
+    $this->assertEquals($expectedToken, $payout->getToken());
+  }
+
+  public function testAmount()
+  {
+    $expectedAmount = 10.0;
+
+    $payout = $this->createClassObject();
+    $payout->setAmount($expectedAmount);
+    $this->assertEquals($expectedAmount, $payout->getAmount());
+  }
+
+  public function testGetCurrency()
+  {
+    $expectedCurrency = Currency::USD;
+
+    $payout = $this->createClassObject();
+    $payout->setCurrency($expectedCurrency);
+    $this->assertEquals($expectedCurrency, $payout->getCurrency());
+  }
+
+  public function testGetCurrencyException()
+  {
+    $expectedCurrency = 'ZZZ';
+
+    $payout = $this->createClassObject();
+    $this->expectException(BitPayException::class);
+    $this->expectExceptionMessage('currency code must be a type of Model.Currency');
+    $payout->setCurrency($expectedCurrency);
+  }
+
+  public function testGetEffectiveDate()
+  {
+    $expectedEffectiveDate = '2021-05-27T09:00:00.000Z';
+
+    $payout = $this->createClassObject();
+    $payout->setEffectiveDate($expectedEffectiveDate);
+    $this->assertEquals($expectedEffectiveDate, $payout->getEffectiveDate());
+  }
+
+  public function testGetLedgerCurrency()
+  {
+    $expectedLedgerCurrency = 'GBP';
+
+    $payout = $this->createClassObject();
+    $payout->setLedgerCurrency($expectedLedgerCurrency);
+    $this->assertEquals($expectedLedgerCurrency, $payout->getLedgerCurrency());
+  }
+
+  public function testGetLedgerCurrencyException()
+  {
+    $expectedLedgerCurrency = 'ZZZ';
+
+    $payout = $this->createClassObject();
+    $this->expectException(BitPayException::class);
+    $this->expectExceptionMessage('currency code must be a type of Model.Currency');
+    $payout->setLedgerCurrency($expectedLedgerCurrency);
+  }
+
+  public function testGetReference()
+  {
+    $expectedReference = 'payout_20210527';
+
+    $payout = $this->createClassObject();
+    $payout->setReference($expectedReference);
+    $this->assertEquals($expectedReference, $payout->getReference());
+  }
+
+  public function testGetNotificationUrl()
+  {
+    $expectedNotificationUrl = 'http://example.com';
+
+    $bill = $this->createClassObject();
+    $bill->setNotificationUrl($expectedNotificationUrl);
+    $this->assertEquals($expectedNotificationUrl, $bill->getNotificationUrl());
+  }
+
+  public function testGetNotificationEmail()
+  {
+    $expectedNotificationEmail = 'test@test.com';
+
+    $payout = $this->createClassObject();
+    $payout->setNotificationEmail($expectedNotificationEmail);
+    $this->assertEquals($expectedNotificationEmail, $payout->getNotificationEmail());
+  }
+
+  public function testGetEmail()
+  {
+    $expectedEmail = 'test@test.com';
+
+    $payout = $this->createClassObject();
+    $payout->setEmail($expectedEmail);
+    $this->assertEquals($expectedEmail, $payout->getEmail());
+  }
+
+  public function testGetRecipientId()
+  {
+    $expectedRecipientId = 'LDxRZCGq174SF8AnQpdBPB';
+
+    $payout = $this->createClassObject();
+    $payout->setRecipientId($expectedRecipientId);
+    $this->assertEquals($expectedRecipientId, $payout->getRecipientId());
+  }
+
+  public function testGetShopperId()
+  {
+    $expectedShopperId = '7qohDf2zZnQK5Qanj8oyC2';
+
+    $payout = $this->createClassObject();
+    $payout->setShopperId($expectedShopperId);
+    $this->assertEquals($expectedShopperId, $payout->getShopperId());
+  }
+
+  public function testGetLabel()
+  {
+    $expectedLabel = 'My label';
+
+    $payout = $this->createClassObject();
+    $payout->setLabel($expectedLabel);
+    $this->assertEquals($expectedLabel, $payout->getLabel());
+  }
+
+  public function testGetMessage()
+  {
+    $expectedMessage = 'My message';
+
+    $payout = $this->createClassObject();
+    $payout->setMessage($expectedMessage);
+    $this->assertEquals($expectedMessage, $payout->getMessage());
+  }
+
+  public function testGetId()
+  {
+    $expectedId = 'abcd123';
+
+    $payout = $this->createClassObject();
+    $payout->setId($expectedId);
+    $this->assertEquals($expectedId, $payout->getId());
+  }
+
+  public function testGetStatus()
+  {
+    $expectedStatus = 'success';
+
+    $payout = $this->createClassObject();
+    $payout->setStatus($expectedStatus);
+    $this->assertEquals($expectedStatus, $payout->getStatus());
+  }
+
+  public function testGetRequestDate()
+  {
+    $expectedRequestDate = '2021-05-27T10:47:37.834Z';
+
+    $payout = $this->createClassObject();
+    $payout->setRequestDate($expectedRequestDate);
+    $this->assertEquals($expectedRequestDate, $payout->getRequestDate());
+  }
+
+  public function testGetExchangeRates()
+  {
+    $expectedExchangeRates = [
+      'BTC' => [
+        'USD' => 39390.47,
+        'GBP' => 27883.962246420004
+      ]
+    ];
+
+    $payout = $this->createClassObject();
+    $payout->setExchangeRates($expectedExchangeRates);
+    $this->assertEquals($expectedExchangeRates, $payout->getExchangeRates());
+  }
+
+  public function testGetTransactions()
+  {
+    $expectedTransactions = [
+      [
+        'txid' => 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057',
+        'amount' => 0.000254,
+        'date' => '2021-05-27T11:04:23.155Z'
+      ]
+    ];
+
+    $payout = $this->createClassObject();
+    $payout->setTransactions($expectedTransactions);
+    $this->assertEquals($expectedTransactions, $payout->getTransactions());
+  }
+
+  public function testFormatAmount()
+  {
+    $amount = 12.3456789;
+    $expectedFormattedAmount = 12.35;
+
+    $payout = $this->createClassObject();
+    $payout->setAmount($amount);
+    $payout->formatAmount(2);
+    $this->assertEquals($expectedFormattedAmount, $payout->getAmount());
+  }
+
+  public function testToArray()
+  {
+    $payout = $this->createClassObject();
+    $this->objectSetters($payout);
+    $payoutArray = $payout->toArray();
+
+    $payoutTransaction = new PayoutTransaction();
+    $payoutTransaction->setTxid('db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057');
+    $payoutTransaction->setAmount(0.000254);
+    $payoutTransaction->setDate('2021-05-27T11:04:23.155Z');
+
+    $transactions = [];
+    array_push($transactions, $payoutTransaction);
+
+    $this->assertNotNull($payoutArray);
+    $this->assertIsArray($payoutArray);
+
+    $this->assertArrayHasKey('token', $payoutArray);
+    $this->assertArrayHasKey('amount', $payoutArray);
+    $this->assertArrayHasKey('currency', $payoutArray);
+    $this->assertArrayHasKey('effectiveDate', $payoutArray);
+    $this->assertArrayHasKey('ledgerCurrency', $payoutArray);
+    $this->assertArrayHasKey('reference', $payoutArray);
+    $this->assertArrayHasKey('notificationURL', $payoutArray);
+    $this->assertArrayHasKey('notificationEmail', $payoutArray);
+    $this->assertArrayHasKey('email', $payoutArray);
+    $this->assertArrayHasKey('recipientId', $payoutArray);
+    $this->assertArrayHasKey('shopperId', $payoutArray);
+    $this->assertArrayHasKey('label', $payoutArray);
+    $this->assertArrayHasKey('message', $payoutArray);
+    $this->assertArrayHasKey('id', $payoutArray);
+    $this->assertArrayHasKey('status', $payoutArray);
+    $this->assertArrayHasKey('requestDate', $payoutArray);
+    $this->assertArrayHasKey('exchangeRates', $payoutArray);
+    $this->assertArrayHasKey('transactions', $payoutArray);
+
+    $this->assertEquals($payoutArray['token'], '6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    $this->assertEquals($payoutArray['amount'], 10.0);
+    $this->assertEquals($payoutArray['currency'], Currency::USD);
+    $this->assertEquals($payoutArray['effectiveDate'], '2021-05-27T09:00:00.000Z');
+    $this->assertEquals($payoutArray['ledgerCurrency'], Currency::GBP);
+    $this->assertEquals($payoutArray['reference'], 'payout_20210527');
+    $this->assertEquals($payoutArray['notificationURL'], 'http://example.com');
+    $this->assertEquals($payoutArray['notificationEmail'], 'test@test.com');
+    $this->assertEquals($payoutArray['email'], 'test@test.com');
+    $this->assertEquals($payoutArray['recipientId'], 'LDxRZCGq174SF8AnQpdBPB');
+    $this->assertEquals($payoutArray['shopperId'], '7qohDf2zZnQK5Qanj8oyC2');
+    $this->assertEquals($payoutArray['label'], 'My label');
+    $this->assertEquals($payoutArray['message'], 'My message');
+    $this->assertEquals($payoutArray['id'], 'JMwv8wQCXANoU2ZZQ9a9GH');
+    $this->assertEquals($payoutArray['status'], 'success');
+    $this->assertEquals($payoutArray['requestDate'], '2021-05-27T10:47:37.834Z');
+    $this->assertEquals($payoutArray['exchangeRates'], [
+      'BTC' => [
+        'USD' => 39390.47,
+        'GBP' => 27883.962246420004
+      ]
+    ]);
+    $this->assertEquals($payoutArray['transactions'][0]['txid'], 'db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057');
+    $this->assertEquals($payoutArray['transactions'][0]['amount'], 0.000254);
+    $this->assertEquals($payoutArray['transactions'][0]['date'], '2021-05-27T11:04:23.155Z');
+  }
+
+  public function testToArrayEmptyKey()
+  {
+    $payout = $this->createClassObject();
+    $payoutArray = $payout->toArray();
+
+    $this->assertNotNull($payoutArray);
+    $this->assertIsArray($payoutArray);
+
+    $this->assertArrayNotHasKey('token', $payoutArray);
+  }
+
+  private function createClassObject()
+  {
+    return new Payout();
+  }
+
+  private function objectSetters(Payout $payout)
+  {
+    $payoutTransaction = new PayoutTransaction();
+    $payoutTransaction->setTxid('db53d7e2bf3385a31257ce09396202d9c2823370a5ca186db315c45e24594057');
+    $payoutTransaction->setAmount(0.000254);
+    $payoutTransaction->setDate('2021-05-27T11:04:23.155Z');
+
+    $transactions = [];
+    array_push($transactions, $payoutTransaction);
+    
+    $payout->setToken('6RZSTPtnzEaroAe2X4YijenRiqteRDNvzbT8NjtcHjUVd9FUFwa7dsX8RFgRDDC5SL');
+    $payout->setAmount(10.0);
+    $payout->setCurrency(Currency::USD);
+    $payout->setEffectiveDate('2021-05-27T09:00:00.000Z');
+    $payout->setLedgerCurrency(Currency::GBP);
+    $payout->setReference('payout_20210527');
+    $payout->setNotificationURL('http://example.com');
+    $payout->setNotificationEmail('test@test.com');
+    $payout->setEmail('test@test.com');
+    $payout->setRecipientId('LDxRZCGq174SF8AnQpdBPB');
+    $payout->setShopperId('7qohDf2zZnQK5Qanj8oyC2');
+    $payout->setLabel('My label');
+    $payout->setMessage('My message');
+    $payout->setId('JMwv8wQCXANoU2ZZQ9a9GH');
+    $payout->setStatus('success');
+    $payout->setRequestDate('2021-05-27T10:47:37.834Z');
+    $payout->setExchangeRates([
+      'BTC' => [
+        'USD' => 39390.47,
+        'GBP' => 27883.962246420004
+      ]
+    ]);
+    $payout->setTransactions($transactions);
+  }
+}


### PR DESCRIPTION
# Overview

This pull request adds tests for all Payout models.

It also addresses an issue:
* Calls to array keys with `->key` instead of `['key']`

<img width="1302" alt="Screen Shot 2022-09-11 at 3 52 37 PM" src="https://user-images.githubusercontent.com/123703/189546451-a48a1d29-6b4a-4d61-a99b-fd846fcf2d29.png">

# Caveats

While I noticed this in `BitPaySDK\Model\Payout\PayoutReceivedInfo`, we should address in a future version how `toArray()` works.

Currently, it generally looks like this across all models:
```php
public function toArray()
    {
        $elements = [
            'name'    => $this->getName(),
            'email'   => $this->getEmail(),
            'address' => $this->getAddress()->toArray(),
        ];

        foreach ($elements as $key => $value) {
            if (empty($value)) {
                unset($elements[$key]);
            }
        }

        return $elements;
    }
```

The problem is that if we don't pass an address, it can't have `toArray()` run on it. Since address is not mandatory here, we should consider building `$elements` only on properties that are set _or_ nulling all unset properties before building `$elements`. We should weigh efficiency and proceed after discussing.