### PR TITLE
SP-224 Fixed deprecation warning

### DIFF
--- a/src/BitPaySDK/Exceptions/BitPayException.php
+++ b/src/BitPaySDK/Exceptions/BitPayException.php
@@ -23,6 +23,7 @@ class BitPayException extends Exception
             $message = $this->bitPayCode . ": " . $this->bitPayMessage . "-> " . $message;
         }
         $this->apiCode = $apiCode;
+        $code = $code ?? 100;
         parent::__construct($message, $code, $previous);
     }
 


### PR DESCRIPTION
Sometimes the $code was explicitly set to null causing the Exception constructor to throw a warning. To fix this, the $code is checked in the method and set to default value in case of null.