### PR TITLE
Improve null and boolean assertions

### DIFF
--- a/test/functional/BitPaySDK/PayoutRecipientsClientTest.php
+++ b/test/functional/BitPaySDK/PayoutRecipientsClientTest.php
@@ -59,7 +59,7 @@ class PayoutRecipientsClientTest extends AbstractClientTestCase
         self::assertEquals('test@emaill1.com', $recipient->getEmail());
         self::assertEquals('recipient1', $recipient->getLabel());
         self::assertEquals('invited', $recipient->getStatus());
-        self::assertEquals(null, $recipient->getShopperId());
+        self::assertNull($recipient->getShopperId());
     }
 
     public function testPayoutRecipientShouldCatchRestCliException(): void
@@ -117,7 +117,7 @@ class PayoutRecipientsClientTest extends AbstractClientTestCase
 
         $result = $this->client->deletePayoutRecipient($payoutRecipientId);
 
-        self::assertEquals(true, $result);
+        self::assertTrue($result);
     }
 
     public function testPayoutRecipientRequestNotification(): void
@@ -135,6 +135,6 @@ class PayoutRecipientsClientTest extends AbstractClientTestCase
 
         $result = $this->client->requestPayoutRecipientNotification($payoutRecipientId);
 
-        self::assertEquals(true, $result);
+        self::assertTrue($result);
     }
 }

--- a/test/unit/BitPaySDK/ClientTest.php
+++ b/test/unit/BitPaySDK/ClientTest.php
@@ -3095,7 +3095,7 @@ class ClientTest extends TestCase
 
         $result = $testedObject->cancelInvoice(self::TEST_INVOICE_ID, $params['forceCancel']);
         self::assertEquals(self::TEST_INVOICE_ID, $result->getId());
-        self::assertEquals(true, $result->getIsCancelled());
+        self::assertTrue($result->getIsCancelled());
     }
 
     /**
@@ -3149,7 +3149,7 @@ class ClientTest extends TestCase
         $result = $testedObject->cancelInvoiceByGuid(self::TEST_INVOICE_GUID, $params['forceCancel']);
         self::assertEquals(self::TEST_INVOICE_GUID, $result->getGuid());
         self::assertEquals(self::TEST_INVOICE_ID, $result->getId());
-        self::assertEquals(true, $result->getIsCancelled());
+        self::assertTrue($result->getIsCancelled());
     }
 
     /**

--- a/test/unit/BitPaySDK/Exceptions/BitPayExceptionTest.php
+++ b/test/unit/BitPaySDK/Exceptions/BitPayExceptionTest.php
@@ -21,7 +21,7 @@ class BitPayExceptionTest extends TestCase
   {
     $exception = $this->createClassObject();
     
-    self::assertEquals(null, $exception->getApiCode());
+    self::assertNull($exception->getApiCode());
   }
 
   public function testDefaultCode()

--- a/test/unit/BitPaySDK/Model/Bill/BillTest.php
+++ b/test/unit/BitPaySDK/Model/Bill/BillTest.php
@@ -259,7 +259,7 @@ class BillTest extends TestCase
         self::assertEquals([''], $billArray['cc']);
         self::assertEquals('123456789', $billArray['phone']);
         self::assertEquals('2022-01-01', $billArray['dueDate']);
-        self::assertEquals(true, $billArray['passProcessingFee']);
+        self::assertTrue($billArray['passProcessingFee']);
         self::assertEquals('status', $billArray['status']);
         self::assertEquals('http://test.com', $billArray['url']);
         self::assertEquals('2022-01-01', $billArray['createDate']);

--- a/test/unit/BitPaySDK/Model/CurrencyTest.php
+++ b/test/unit/BitPaySDK/Model/CurrencyTest.php
@@ -53,12 +53,12 @@ class CurrencyTest extends TestCase
         self::assertEquals('BTC', $currencyArray['code']);
         self::assertEquals('Symbol', $currencyArray['symbol']);
         self::assertEquals(1, $currencyArray['precision']);
-        self::assertEquals(true, $currencyArray['currentlySettled']);
+        self::assertTrue($currencyArray['currentlySettled']);
         self::assertEquals('Bitcoin', $currencyArray['name']);
         self::assertEquals('plural', $currencyArray['plural']);
         self::assertEquals('alts', $currencyArray['alts']);
         self::assertEquals('minimum', $currencyArray['minimum']);
-        self::assertEquals(true, $currencyArray['sanctioned']);
+        self::assertTrue($currencyArray['sanctioned']);
         self::assertEquals('decimals', $currencyArray['decimals']);
         self::assertEquals(['test'], $currencyArray['payoutFields']);
         self::assertEquals(['test'], $currencyArray['settlementMinimum']);
@@ -89,7 +89,7 @@ class CurrencyTest extends TestCase
     {
         $currency = $this->createClassObject();
         $currency->setCurrentlySettled(true);
-        self::assertEquals(true, $currency->getCurrentlySettled());
+        self::assertTrue($currency->getCurrentlySettled());
     }
 
     public function testGetName()
@@ -124,7 +124,7 @@ class CurrencyTest extends TestCase
     {
         $currency = $this->createClassObject();
         $currency->setSanctioned(true);
-        self::assertEquals(true, $currency->getSanctioned());
+        self::assertTrue($currency->getSanctioned());
     }
 
     public function testGetDecimals()

--- a/test/unit/BitPaySDK/Model/Invoice/BuyerProvidedInfoTest.php
+++ b/test/unit/BitPaySDK/Model/Invoice/BuyerProvidedInfoTest.php
@@ -113,7 +113,7 @@ class BuyerProvidedInfoTest extends TestCase
         self::assertEquals('example@bitpay.com', $buyerProvidedInfoArray['emailAddress']);
         self::assertEquals('BTC', $buyerProvidedInfoArray['selectedTransactionCurrency']);
         self::assertEquals('4445556666', $buyerProvidedInfoArray['sms']);
-        self::assertEquals(true, $buyerProvidedInfoArray['smsVerified']);
+        self::assertTrue($buyerProvidedInfoArray['smsVerified']);
     }
 
     public function testToArrayEmptyKey()

--- a/test/unit/BitPaySDK/Model/Invoice/ItemizedDetailsTest.php
+++ b/test/unit/BitPaySDK/Model/Invoice/ItemizedDetailsTest.php
@@ -53,7 +53,7 @@ class ItemizedDetailsTest extends TestCase
 
         self::assertEquals(15.5, $itemizedDetailsArray['amount']);
         self::assertEquals('Test description', $itemizedDetailsArray['description']);
-        self::assertEquals(true, $itemizedDetailsArray['isFee']);
+        self::assertTrue($itemizedDetailsArray['isFee']);
     }
 
     private function createClassObject(): ItemizedDetails

--- a/test/unit/BitPaySDK/Model/Invoice/RefundTest.php
+++ b/test/unit/BitPaySDK/Model/Invoice/RefundTest.php
@@ -175,11 +175,11 @@ class RefundTest extends TestCase
         self::assertEquals('2022-01-01', $refundArray['requestDate']);
         self::assertEquals('pending', $refundArray['status']);
         self::assertEquals('11', $refundArray['invoiceId']);
-        self::assertEquals(true, $refundArray['preview']);
-        self::assertEquals(true, $refundArray['immediate']);
+        self::assertTrue($refundArray['preview']);
+        self::assertTrue($refundArray['immediate']);
         self::assertEquals(1.0, $refundArray['refundFee']);
         self::assertEquals('Invoice', $refundArray['invoice']);
-        self::assertEquals(true, $refundArray['buyerPaysRefundFee']);
+        self::assertTrue($refundArray['buyerPaysRefundFee']);
         self::assertEquals('Reference', $refundArray['reference']);
         self::assertEquals('Last refunded notification', $refundArray['lastRefundNotification']);
     }

--- a/test/unit/BitPaySDK/Model/Invoice/RefundWebhookTest.php
+++ b/test/unit/BitPaySDK/Model/Invoice/RefundWebhookTest.php
@@ -138,8 +138,8 @@ class RefundWebhookTest extends TestCase
     self::assertEquals('USD', $refundWebhookArray['currency']);
     self::assertEquals('2022-01-11T16:58:23.967Z', $refundWebhookArray['lastRefundNotification']);
     self::assertEquals(2.31, $refundWebhookArray['refundFee']);
-    self::assertEquals(false, $refundWebhookArray['immediate']);
-    self::assertEquals(true, $refundWebhookArray['buyerPaysRefundFee']);
+    self::assertFalse($refundWebhookArray['immediate']);
+    self::assertTrue($refundWebhookArray['buyerPaysRefundFee']);
     self::assertEquals('2022-01-11T16:58:23.000Z', $refundWebhookArray['requestDate']);
   }
 

--- a/test/unit/BitPaySDK/Model/Invoice/SupportedTransactionCurrencyTest.php
+++ b/test/unit/BitPaySDK/Model/Invoice/SupportedTransactionCurrencyTest.php
@@ -42,7 +42,7 @@ class SupportedTransactionCurrencyTest extends TestCase
     self::assertArrayHasKey('enabled', $supportedTransactionCurrencyArray);
     self::assertArrayHasKey('reason', $supportedTransactionCurrencyArray);
 
-    self::assertEquals(true, $supportedTransactionCurrencyArray['enabled']);
+    self::assertTrue($supportedTransactionCurrencyArray['enabled']);
     self::assertEquals("My reason", $supportedTransactionCurrencyArray['reason']);
   }
 

--- a/test/unit/BitPaySDK/Model/Wallet/CurrenciesTest.php
+++ b/test/unit/BitPaySDK/Model/Wallet/CurrenciesTest.php
@@ -100,14 +100,14 @@ class CurrenciesTest extends TestCase
     self::assertArrayHasKey('walletConnect', $currenciesArray);
 
     self::assertEquals('BTH', $currenciesArray['code']);
-    self::assertEquals(true, $currenciesArray['p2p']);
-    self::assertEquals(true, $currenciesArray['dappBrowser']);
+    self::assertTrue($currenciesArray['p2p']);
+    self::assertTrue($currenciesArray['dappBrowser']);
     self::assertEquals('https://bitpay.com/api/images/logo-6fa5404d.svg', $currenciesArray['image']);
-    self::assertEquals(true, $currenciesArray['paypro']);
+    self::assertTrue($currenciesArray['paypro']);
     self::assertEquals('BIP21', $currenciesArray['qr']['type']);
-    self::assertEquals(false, $currenciesArray['qr']['collapsed']);
+    self::assertFalse($currenciesArray['qr']['collapsed']);
     self::assertEquals('1.23', $currenciesArray['withdrawalFee']);
-    self::assertEquals(true, $currenciesArray['walletConnect']);
+    self::assertTrue($currenciesArray['walletConnect']);
   }
 
   private function createClassObject(): Currencies

--- a/test/unit/BitPaySDK/Model/Wallet/CurrencyQrTest.php
+++ b/test/unit/BitPaySDK/Model/Wallet/CurrencyQrTest.php
@@ -42,7 +42,7 @@ class CurrencyQrTest extends TestCase
     self::assertArrayHasKey('collapsed', $currencyQrArray);
 
     self::assertEquals('BIP21', $currencyQrArray['type']);
-    self::assertEquals(false, $currencyQrArray['collapsed']);
+    self::assertFalse($currencyQrArray['collapsed']);
   }
 
   private function createClassObject(): CurrencyQr


### PR DESCRIPTION
# Changed log

- Using the `assertNull` to assert the expected is `null`.
- Using the `assertFalse` and `assertTrue` to assert the expected is `true` or `false` boolean.