### PR TITLE
SP-126 Added X-BitPay-Platform-Info header

### DIFF
--- a/docs/classes/BitPaySDK-Client.html
+++ b/docs/classes/BitPaySDK-Client.html
@@ -811,7 +811,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">294</span>
+    <span class="phpdocumentor-element-found-in__line">297</span>
 
     </aside>
 
@@ -906,7 +906,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">313</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -1001,7 +1001,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">892</span>
+    <span class="phpdocumentor-element-found-in__line">895</span>
 
     </aside>
 
@@ -1085,7 +1085,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">940</span>
+    <span class="phpdocumentor-element-found-in__line">943</span>
 
     </aside>
 
@@ -1166,7 +1166,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">488</span>
+    <span class="phpdocumentor-element-found-in__line">491</span>
 
     </aside>
 
@@ -1246,7 +1246,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">505</span>
+    <span class="phpdocumentor-element-found-in__line">508</span>
 
     </aside>
 
@@ -1326,7 +1326,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">541</span>
+    <span class="phpdocumentor-element-found-in__line">544</span>
 
     </aside>
 
@@ -1428,7 +1428,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">153</span>
+    <span class="phpdocumentor-element-found-in__line">156</span>
 
     </aside>
 
@@ -1530,7 +1530,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">925</span>
+    <span class="phpdocumentor-element-found-in__line">928</span>
 
     </aside>
 
@@ -1611,7 +1611,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">358</span>
+    <span class="phpdocumentor-element-found-in__line">361</span>
 
     </aside>
 
@@ -1758,7 +1758,7 @@ or at time of processing</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">78</span>
+    <span class="phpdocumentor-element-found-in__line">79</span>
 
     </aside>
 
@@ -1766,7 +1766,7 @@ or at time of processing</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">createWithData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$privateKey</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/BitPaySDK-Tokens.html"><abbr title="\BitPaySDK\Tokens">Tokens</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokens</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$privateKeySecret</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$proxy</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/BitPaySDK-Client.html"><abbr title="\BitPaySDK\Client">Client</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">createWithData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$privateKey</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/BitPaySDK-Tokens.html"><abbr title="\BitPaySDK\Tokens">Tokens</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokens</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$privateKeySecret</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$proxy</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$platformInfo</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/BitPaySDK-Client.html"><abbr title="\BitPaySDK\Client">Client</abbr></a></span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -1820,6 +1820,15 @@ http://********.com:3128</p>
 </section>
 
             </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$platformInfo</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Value for the X-BitPay-Platform header.</p>
+</section>
+
+            </dd>
             </dl>
 
     
@@ -1869,7 +1878,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">106</span>
+    <span class="phpdocumentor-element-found-in__line">109</span>
 
     </aside>
 
@@ -1877,7 +1886,7 @@ http://********.com:3128</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">createWithFile</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$configFilePath</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/BitPaySDK-Client.html"><abbr title="\BitPaySDK\Client">Client</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">createWithFile</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$configFilePath</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$platformInfo</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/BitPaySDK-Client.html"><abbr title="\BitPaySDK\Client">Client</abbr></a></span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -1891,6 +1900,15 @@ http://********.com:3128</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The path to the configuration file.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$platformInfo</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Value for the X-BitPay-Platform header.</p>
 </section>
 
             </dd>
@@ -1935,7 +1953,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">793</span>
+    <span class="phpdocumentor-element-found-in__line">796</span>
 
     </aside>
 
@@ -2023,7 +2041,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">614</span>
+    <span class="phpdocumentor-element-found-in__line">617</span>
 
     </aside>
 
@@ -2125,7 +2143,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">560</span>
+    <span class="phpdocumentor-element-found-in__line">563</span>
 
     </aside>
 
@@ -2227,7 +2245,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">577</span>
+    <span class="phpdocumentor-element-found-in__line">580</span>
 
     </aside>
 
@@ -2309,7 +2327,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">668</span>
+    <span class="phpdocumentor-element-found-in__line">671</span>
 
     </aside>
 
@@ -2407,7 +2425,7 @@ Current supported values are BTC, BCH, ETH, XRP, DOGE and LTC</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">648</span>
+    <span class="phpdocumentor-element-found-in__line">651</span>
 
     </aside>
 
@@ -2496,7 +2514,7 @@ Current supported values are BTC, BCH, ETH, XRP, DOGE and LTC</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">202</span>
+    <span class="phpdocumentor-element-found-in__line">205</span>
 
     </aside>
 
@@ -2599,7 +2617,7 @@ authorized for the specified facade (the public facade requires no authorization
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">226</span>
+    <span class="phpdocumentor-element-found-in__line">229</span>
 
     </aside>
 
@@ -2703,7 +2721,7 @@ authorized for the specified facade (the public facade requires no authorization
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">254</span>
+    <span class="phpdocumentor-element-found-in__line">257</span>
 
     </aside>
 
@@ -2833,7 +2851,7 @@ with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">687</span>
+    <span class="phpdocumentor-element-found-in__line">690</span>
 
     </aside>
 
@@ -2939,7 +2957,7 @@ with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">703</span>
+    <span class="phpdocumentor-element-found-in__line">706</span>
 
     </aside>
 
@@ -3015,7 +3033,7 @@ with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">846</span>
+    <span class="phpdocumentor-element-found-in__line">849</span>
 
     </aside>
 
@@ -3100,7 +3118,7 @@ for the payout facade.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">738</span>
+    <span class="phpdocumentor-element-found-in__line">741</span>
 
     </aside>
 
@@ -3185,7 +3203,7 @@ payout facade.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">758</span>
+    <span class="phpdocumentor-element-found-in__line">761</span>
 
     </aside>
 
@@ -3288,7 +3306,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">869</span>
+    <span class="phpdocumentor-element-found-in__line">872</span>
 
     </aside>
 
@@ -3418,7 +3436,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">629</span>
+    <span class="phpdocumentor-element-found-in__line">632</span>
 
     </aside>
 
@@ -3488,7 +3506,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">437</span>
+    <span class="phpdocumentor-element-found-in__line">440</span>
 
     </aside>
 
@@ -3576,7 +3594,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">455</span>
+    <span class="phpdocumentor-element-found-in__line">458</span>
 
     </aside>
 
@@ -3664,7 +3682,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">419</span>
+    <span class="phpdocumentor-element-found-in__line">422</span>
 
     </aside>
 
@@ -3740,7 +3758,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">987</span>
+    <span class="phpdocumentor-element-found-in__line">990</span>
 
     </aside>
 
@@ -3824,7 +3842,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1005</span>
+    <span class="phpdocumentor-element-found-in__line">1008</span>
 
     </aside>
 
@@ -3917,7 +3935,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">964</span>
+    <span class="phpdocumentor-element-found-in__line">967</span>
 
     </aside>
 
@@ -4049,7 +4067,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">522</span>
+    <span class="phpdocumentor-element-found-in__line">525</span>
 
     </aside>
 
@@ -4121,7 +4139,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">134</span>
+    <span class="phpdocumentor-element-found-in__line">137</span>
 
     </aside>
 
@@ -4183,7 +4201,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">331</span>
+    <span class="phpdocumentor-element-found-in__line">334</span>
 
     </aside>
 
@@ -4270,7 +4288,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">277</span>
+    <span class="phpdocumentor-element-found-in__line">280</span>
 
     </aside>
 
@@ -4358,7 +4376,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">910</span>
+    <span class="phpdocumentor-element-found-in__line">913</span>
 
     </aside>
 
@@ -4442,7 +4460,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">811</span>
+    <span class="phpdocumentor-element-found-in__line">814</span>
 
     </aside>
 
@@ -4530,7 +4548,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">472</span>
+    <span class="phpdocumentor-element-found-in__line">475</span>
 
     </aside>
 
@@ -4610,7 +4628,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">828</span>
+    <span class="phpdocumentor-element-found-in__line">831</span>
 
     </aside>
 
@@ -4694,7 +4712,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">720</span>
+    <span class="phpdocumentor-element-found-in__line">723</span>
 
     </aside>
 
@@ -4782,7 +4800,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">595</span>
+    <span class="phpdocumentor-element-found-in__line">598</span>
 
     </aside>
 
@@ -4875,7 +4893,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">177</span>
+    <span class="phpdocumentor-element-found-in__line">180</span>
 
     </aside>
 
@@ -4995,7 +5013,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">776</span>
+    <span class="phpdocumentor-element-found-in__line">779</span>
 
     </aside>
 
@@ -5088,7 +5106,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">382</span>
+    <span class="phpdocumentor-element-found-in__line">385</span>
 
     </aside>
 
@@ -5177,7 +5195,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">401</span>
+    <span class="phpdocumentor-element-found-in__line">404</span>
 
     </aside>
 
@@ -5266,7 +5284,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1104</span>
+    <span class="phpdocumentor-element-found-in__line">1107</span>
 
     </aside>
 
@@ -5309,7 +5327,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1074</span>
+    <span class="phpdocumentor-element-found-in__line">1077</span>
 
     </aside>
 
@@ -5352,7 +5370,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1124</span>
+    <span class="phpdocumentor-element-found-in__line">1127</span>
 
     </aside>
 
@@ -5395,7 +5413,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1144</span>
+    <span class="phpdocumentor-element-found-in__line">1147</span>
 
     </aside>
 
@@ -5438,7 +5456,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1134</span>
+    <span class="phpdocumentor-element-found-in__line">1137</span>
 
     </aside>
 
@@ -5481,7 +5499,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1114</span>
+    <span class="phpdocumentor-element-found-in__line">1117</span>
 
     </aside>
 
@@ -5524,7 +5542,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1084</span>
+    <span class="phpdocumentor-element-found-in__line">1087</span>
 
     </aside>
 
@@ -5567,7 +5585,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1154</span>
+    <span class="phpdocumentor-element-found-in__line">1157</span>
 
     </aside>
 
@@ -5610,7 +5628,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1094</span>
+    <span class="phpdocumentor-element-found-in__line">1097</span>
 
     </aside>
 
@@ -5653,7 +5671,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1044</span>
+    <span class="phpdocumentor-element-found-in__line">1047</span>
 
     </aside>
 
@@ -5716,7 +5734,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1064</span>
+    <span class="phpdocumentor-element-found-in__line">1067</span>
 
     </aside>
 
@@ -5755,7 +5773,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1019</span>
+    <span class="phpdocumentor-element-found-in__line">1022</span>
 
     </aside>
 

--- a/docs/classes/BitPaySDK-PosClient.html
+++ b/docs/classes/BitPaySDK-PosClient.html
@@ -760,7 +760,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">36</span>
+    <span class="phpdocumentor-element-found-in__line">35</span>
 
     </aside>
 
@@ -833,7 +833,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">38</span>
+    <span class="phpdocumentor-element-found-in__line">37</span>
 
     </aside>
 
@@ -869,7 +869,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">37</span>
+    <span class="phpdocumentor-element-found-in__line">36</span>
 
     </aside>
 
@@ -946,7 +946,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">49</span>
+    <span class="phpdocumentor-element-found-in__line">48</span>
 
     </aside>
 
@@ -2542,7 +2542,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">87</span>
+    <span class="phpdocumentor-element-found-in__line">86</span>
 
     </aside>
 
@@ -6054,7 +6054,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">69</span>
+    <span class="phpdocumentor-element-found-in__line">68</span>
 
     </aside>
 

--- a/docs/classes/BitPaySDK-PosClient.html
+++ b/docs/classes/BitPaySDK-PosClient.html
@@ -216,6 +216,13 @@
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/BitPaySDK-PosClient.html#property_platformInfo">$platformInfo</a>
+    <span>
+                        &nbsp;: string            </span>
+</dt>
+<dd>Value for the X-BitPay-Platform-Info header</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/BitPaySDK-Client.html#property_restCli">$restCli</a>
     <span>
                         &nbsp;: <a href="classes/BitPaySDK-Util-RESTcli-RESTcli.html"><abbr title="\BitPaySDK\Util\RESTcli\RESTcli">RESTcli</abbr></a>            </span>
@@ -743,6 +750,43 @@ payout facade.</dd>
             -protected
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="property_platformInfo">
+        $platformInfo
+        <a href="classes/BitPaySDK-PosClient.html#property_platformInfo" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">36</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Value for the X-BitPay-Platform-Info header</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">protected</span>
+        <span class="phpdocumentor-signature__type">string</span>
+    <span class="phpdocumentor-signature__name">$platformInfo</span>
+    </code>
+
+    
+    
+    
+
+    
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="property_restCli">
         $restCli
         <a href="classes/BitPaySDK-Client.html#property_restCli" class="headerlink"><i class="fas fa-link"></i></a>
@@ -789,7 +833,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">31</span>
+    <span class="phpdocumentor-element-found-in__line">38</span>
 
     </aside>
 
@@ -825,7 +869,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">30</span>
+    <span class="phpdocumentor-element-found-in__line">37</span>
 
     </aside>
 
@@ -902,7 +946,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">41</span>
+    <span class="phpdocumentor-element-found-in__line">49</span>
 
     </aside>
 
@@ -910,7 +954,7 @@ payout facade.</dd>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">mixed&nbsp;</span><span class="phpdocumentor-signature__argument__name">$token</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$token</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$platformInfo</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -920,10 +964,10 @@ payout facade.</dd>
     <dl class="phpdocumentor-argument-list">
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$token</span>
-                : <span class="phpdocumentor-signature__argument__return-type">mixed</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string</span>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>string The token generated on the BitPay account.</p>
+                    <section class="phpdocumentor-description"><p>The token generated on the BitPay account.</p>
 </section>
 
             </dd>
@@ -932,7 +976,16 @@ payout facade.</dd>
                 : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
                  = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
-                    <section class="phpdocumentor-description"><p>string The target environment [Default: Production].</p>
+                    <section class="phpdocumentor-description"><p>The target environment [Default: Production].</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$platformInfo</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Value for the X-BitPay-Platform-Info header.</p>
 </section>
 
             </dd>
@@ -973,7 +1026,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">294</span>
+    <span class="phpdocumentor-element-found-in__line">297</span>
 
     </aside>
 
@@ -1068,7 +1121,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">313</span>
+    <span class="phpdocumentor-element-found-in__line">316</span>
 
     </aside>
 
@@ -1163,7 +1216,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">892</span>
+    <span class="phpdocumentor-element-found-in__line">895</span>
 
     </aside>
 
@@ -1247,7 +1300,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">940</span>
+    <span class="phpdocumentor-element-found-in__line">943</span>
 
     </aside>
 
@@ -1328,7 +1381,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">488</span>
+    <span class="phpdocumentor-element-found-in__line">491</span>
 
     </aside>
 
@@ -1408,7 +1461,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">505</span>
+    <span class="phpdocumentor-element-found-in__line">508</span>
 
     </aside>
 
@@ -1488,7 +1541,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">541</span>
+    <span class="phpdocumentor-element-found-in__line">544</span>
 
     </aside>
 
@@ -1590,7 +1643,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">153</span>
+    <span class="phpdocumentor-element-found-in__line">156</span>
 
     </aside>
 
@@ -1692,7 +1745,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">925</span>
+    <span class="phpdocumentor-element-found-in__line">928</span>
 
     </aside>
 
@@ -1773,7 +1826,7 @@ payout facade.</dd>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">358</span>
+    <span class="phpdocumentor-element-found-in__line">361</span>
 
     </aside>
 
@@ -1920,7 +1973,7 @@ or at time of processing</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">78</span>
+    <span class="phpdocumentor-element-found-in__line">79</span>
 
     </aside>
 
@@ -1928,7 +1981,7 @@ or at time of processing</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">createWithData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$privateKey</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/BitPaySDK-Tokens.html"><abbr title="\BitPaySDK\Tokens">Tokens</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokens</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$privateKeySecret</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$proxy</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/BitPaySDK-Client.html"><abbr title="\BitPaySDK\Client">Client</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">createWithData</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$privateKey</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><a href="classes/BitPaySDK-Tokens.html"><abbr title="\BitPaySDK\Tokens">Tokens</abbr></a>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$tokens</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$privateKeySecret</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$proxy</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$platformInfo</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/BitPaySDK-Client.html"><abbr title="\BitPaySDK\Client">Client</abbr></a></span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -1982,6 +2035,15 @@ http://********.com:3128</p>
 </section>
 
             </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$platformInfo</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Value for the X-BitPay-Platform header.</p>
+</section>
+
+            </dd>
             </dl>
 
     
@@ -2031,7 +2093,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">106</span>
+    <span class="phpdocumentor-element-found-in__line">109</span>
 
     </aside>
 
@@ -2039,7 +2101,7 @@ http://********.com:3128</p>
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">createWithFile</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$configFilePath</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/BitPaySDK-Client.html"><abbr title="\BitPaySDK\Client">Client</abbr></a></span></code>
+            <span class="phpdocumentor-signature__static">static</span>        <span class="phpdocumentor-signature__name">createWithFile</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$configFilePath</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$platformInfo</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type"><a href="classes/BitPaySDK-Client.html"><abbr title="\BitPaySDK\Client">Client</abbr></a></span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -2053,6 +2115,15 @@ http://********.com:3128</p>
                             </dt>
             <dd class="phpdocumentor-argument-list__definition">
                     <section class="phpdocumentor-description"><p>The path to the configuration file.</p>
+</section>
+
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$platformInfo</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                    <section class="phpdocumentor-description"><p>Value for the X-BitPay-Platform header.</p>
 </section>
 
             </dd>
@@ -2097,7 +2168,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">793</span>
+    <span class="phpdocumentor-element-found-in__line">796</span>
 
     </aside>
 
@@ -2185,7 +2256,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">614</span>
+    <span class="phpdocumentor-element-found-in__line">617</span>
 
     </aside>
 
@@ -2287,7 +2358,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">560</span>
+    <span class="phpdocumentor-element-found-in__line">563</span>
 
     </aside>
 
@@ -2389,7 +2460,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">577</span>
+    <span class="phpdocumentor-element-found-in__line">580</span>
 
     </aside>
 
@@ -2471,7 +2542,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">78</span>
+    <span class="phpdocumentor-element-found-in__line">87</span>
 
     </aside>
 
@@ -2537,7 +2608,7 @@ http://********.com:3128</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">668</span>
+    <span class="phpdocumentor-element-found-in__line">671</span>
 
     </aside>
 
@@ -2635,7 +2706,7 @@ Current supported values are BTC, BCH, ETH, XRP, DOGE and LTC</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">648</span>
+    <span class="phpdocumentor-element-found-in__line">651</span>
 
     </aside>
 
@@ -2724,7 +2795,7 @@ Current supported values are BTC, BCH, ETH, XRP, DOGE and LTC</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">202</span>
+    <span class="phpdocumentor-element-found-in__line">205</span>
 
     </aside>
 
@@ -2827,7 +2898,7 @@ authorized for the specified facade (the public facade requires no authorization
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">226</span>
+    <span class="phpdocumentor-element-found-in__line">229</span>
 
     </aside>
 
@@ -2931,7 +3002,7 @@ authorized for the specified facade (the public facade requires no authorization
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">254</span>
+    <span class="phpdocumentor-element-found-in__line">257</span>
 
     </aside>
 
@@ -3061,7 +3132,7 @@ with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">687</span>
+    <span class="phpdocumentor-element-found-in__line">690</span>
 
     </aside>
 
@@ -3167,7 +3238,7 @@ with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">703</span>
+    <span class="phpdocumentor-element-found-in__line">706</span>
 
     </aside>
 
@@ -3243,7 +3314,7 @@ with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">846</span>
+    <span class="phpdocumentor-element-found-in__line">849</span>
 
     </aside>
 
@@ -3328,7 +3399,7 @@ for the payout facade.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">738</span>
+    <span class="phpdocumentor-element-found-in__line">741</span>
 
     </aside>
 
@@ -3413,7 +3484,7 @@ payout facade.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">758</span>
+    <span class="phpdocumentor-element-found-in__line">761</span>
 
     </aside>
 
@@ -3516,7 +3587,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">869</span>
+    <span class="phpdocumentor-element-found-in__line">872</span>
 
     </aside>
 
@@ -3646,7 +3717,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">629</span>
+    <span class="phpdocumentor-element-found-in__line">632</span>
 
     </aside>
 
@@ -3716,7 +3787,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">437</span>
+    <span class="phpdocumentor-element-found-in__line">440</span>
 
     </aside>
 
@@ -3804,7 +3875,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">455</span>
+    <span class="phpdocumentor-element-found-in__line">458</span>
 
     </aside>
 
@@ -3892,7 +3963,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">419</span>
+    <span class="phpdocumentor-element-found-in__line">422</span>
 
     </aside>
 
@@ -3968,7 +4039,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">987</span>
+    <span class="phpdocumentor-element-found-in__line">990</span>
 
     </aside>
 
@@ -4052,7 +4123,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1005</span>
+    <span class="phpdocumentor-element-found-in__line">1008</span>
 
     </aside>
 
@@ -4145,7 +4216,7 @@ starting with the 11th result).</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">964</span>
+    <span class="phpdocumentor-element-found-in__line">967</span>
 
     </aside>
 
@@ -4277,7 +4348,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">522</span>
+    <span class="phpdocumentor-element-found-in__line">525</span>
 
     </aside>
 
@@ -4349,7 +4420,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">134</span>
+    <span class="phpdocumentor-element-found-in__line">137</span>
 
     </aside>
 
@@ -4411,7 +4482,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">331</span>
+    <span class="phpdocumentor-element-found-in__line">334</span>
 
     </aside>
 
@@ -4498,7 +4569,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">277</span>
+    <span class="phpdocumentor-element-found-in__line">280</span>
 
     </aside>
 
@@ -4586,7 +4657,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">910</span>
+    <span class="phpdocumentor-element-found-in__line">913</span>
 
     </aside>
 
@@ -4670,7 +4741,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">811</span>
+    <span class="phpdocumentor-element-found-in__line">814</span>
 
     </aside>
 
@@ -4758,7 +4829,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">472</span>
+    <span class="phpdocumentor-element-found-in__line">475</span>
 
     </aside>
 
@@ -4838,7 +4909,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">828</span>
+    <span class="phpdocumentor-element-found-in__line">831</span>
 
     </aside>
 
@@ -4922,7 +4993,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">720</span>
+    <span class="phpdocumentor-element-found-in__line">723</span>
 
     </aside>
 
@@ -5010,7 +5081,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">595</span>
+    <span class="phpdocumentor-element-found-in__line">598</span>
 
     </aside>
 
@@ -5103,7 +5174,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">177</span>
+    <span class="phpdocumentor-element-found-in__line">180</span>
 
     </aside>
 
@@ -5223,7 +5294,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">776</span>
+    <span class="phpdocumentor-element-found-in__line">779</span>
 
     </aside>
 
@@ -5316,7 +5387,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">382</span>
+    <span class="phpdocumentor-element-found-in__line">385</span>
 
     </aside>
 
@@ -5405,7 +5476,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">401</span>
+    <span class="phpdocumentor-element-found-in__line">404</span>
 
     </aside>
 
@@ -5494,7 +5565,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1104</span>
+    <span class="phpdocumentor-element-found-in__line">1107</span>
 
     </aside>
 
@@ -5537,7 +5608,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1074</span>
+    <span class="phpdocumentor-element-found-in__line">1077</span>
 
     </aside>
 
@@ -5580,7 +5651,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1124</span>
+    <span class="phpdocumentor-element-found-in__line">1127</span>
 
     </aside>
 
@@ -5623,7 +5694,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1144</span>
+    <span class="phpdocumentor-element-found-in__line">1147</span>
 
     </aside>
 
@@ -5666,7 +5737,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1134</span>
+    <span class="phpdocumentor-element-found-in__line">1137</span>
 
     </aside>
 
@@ -5709,7 +5780,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1114</span>
+    <span class="phpdocumentor-element-found-in__line">1117</span>
 
     </aside>
 
@@ -5752,7 +5823,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1084</span>
+    <span class="phpdocumentor-element-found-in__line">1087</span>
 
     </aside>
 
@@ -5795,7 +5866,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1154</span>
+    <span class="phpdocumentor-element-found-in__line">1157</span>
 
     </aside>
 
@@ -5838,7 +5909,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1094</span>
+    <span class="phpdocumentor-element-found-in__line">1097</span>
 
     </aside>
 
@@ -5881,7 +5952,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1044</span>
+    <span class="phpdocumentor-element-found-in__line">1047</span>
 
     </aside>
 
@@ -5944,7 +6015,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1064</span>
+    <span class="phpdocumentor-element-found-in__line">1067</span>
 
     </aside>
 
@@ -5983,7 +6054,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/PosClient.php"><a href="files/src-bitpaysdk-posclient.html"><abbr title="src/BitPaySDK/PosClient.php">PosClient.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">60</span>
+    <span class="phpdocumentor-element-found-in__line">69</span>
 
     </aside>
 
@@ -6033,7 +6104,7 @@ specify pages for large query sets.</p>
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Client.php"><a href="files/src-bitpaysdk-client.html"><abbr title="src/BitPaySDK/Client.php">Client.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">1019</span>
+    <span class="phpdocumentor-element-found-in__line">1022</span>
 
     </aside>
 
@@ -6211,6 +6282,7 @@ specify pages for large query sets.</p>
                 <li>
                     <ul class="phpdocumentor-list -clean">
                                                     <li class=""><a href="classes/BitPaySDK-PosClient.html#property_env">$env</a></li>
+                                                    <li class=""><a href="classes/BitPaySDK-PosClient.html#property_platformInfo">$platformInfo</a></li>
                                                     <li class=""><a href="classes/BitPaySDK-Client.html#property_restCli">$restCli</a></li>
                                                     <li class=""><a href="classes/BitPaySDK-PosClient.html#property_RESTcli">$RESTcli</a></li>
                                                     <li class=""><a href="classes/BitPaySDK-PosClient.html#property_token">$token</a></li>

--- a/docs/classes/BitPaySDK-Util-RESTcli-RESTcli.html
+++ b/docs/classes/BitPaySDK-Util-RESTcli-RESTcli.html
@@ -344,7 +344,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">37</span>
+    <span class="phpdocumentor-element-found-in__line">38</span>
 
     </aside>
 
@@ -416,7 +416,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">41</span>
+    <span class="phpdocumentor-element-found-in__line">43</span>
 
     </aside>
 
@@ -452,7 +452,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">45</span>
+    <span class="phpdocumentor-element-found-in__line">48</span>
 
     </aside>
 
@@ -488,7 +488,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">51</span>
+    <span class="phpdocumentor-element-found-in__line">54</span>
 
     </aside>
 
@@ -525,7 +525,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">56</span>
+    <span class="phpdocumentor-element-found-in__line">59</span>
 
     </aside>
 
@@ -566,7 +566,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">66</span>
+    <span class="phpdocumentor-element-found-in__line">69</span>
 
     </aside>
 
@@ -647,7 +647,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">247</span>
+    <span class="phpdocumentor-element-found-in__line">250</span>
 
     </aside>
 
@@ -726,7 +726,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">184</span>
+    <span class="phpdocumentor-element-found-in__line">187</span>
 
     </aside>
 
@@ -816,7 +816,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">369</span>
+    <span class="phpdocumentor-element-found-in__line">372</span>
 
     </aside>
 
@@ -880,7 +880,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">80</span>
+    <span class="phpdocumentor-element-found-in__line">83</span>
 
     </aside>
 
@@ -930,7 +930,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">120</span>
+    <span class="phpdocumentor-element-found-in__line">123</span>
 
     </aside>
 
@@ -1020,7 +1020,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">312</span>
+    <span class="phpdocumentor-element-found-in__line">315</span>
 
     </aside>
 
@@ -1099,7 +1099,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">406</span>
+    <span class="phpdocumentor-element-found-in__line">409</span>
 
     </aside>
 
@@ -1147,7 +1147,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">422</span>
+    <span class="phpdocumentor-element-found-in__line">425</span>
 
     </aside>
 

--- a/docs/classes/BitPaySDK-Util-RESTcli-RESTcli.html
+++ b/docs/classes/BitPaySDK-Util-RESTcli-RESTcli.html
@@ -233,6 +233,13 @@
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -protected">
+    <a class="" href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_platformInfo">$platformInfo</a>
+    <span>
+                        &nbsp;: string            </span>
+</dt>
+<dd>Value for the X-BitPay-Platform-Info header.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -protected">
     <a class="" href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_proxy">$proxy</a>
     <span>
                         &nbsp;: string            </span>
@@ -471,6 +478,43 @@
             -protected
                                                         "
 >
+    <h4 class="phpdocumentor-element__name" id="property_platformInfo">
+        $platformInfo
+        <a href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_platformInfo" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                                </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">51</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">Value for the X-BitPay-Platform-Info header.</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">protected</span>
+        <span class="phpdocumentor-signature__type">string</span>
+    <span class="phpdocumentor-signature__name">$platformInfo</span>
+    </code>
+
+    
+    
+    
+
+    
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -protected
+                                                        "
+>
     <h4 class="phpdocumentor-element__name" id="property_proxy">
         $proxy
         <a href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_proxy" class="headerlink"><i class="fas fa-link"></i></a>
@@ -481,7 +525,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">50</span>
+    <span class="phpdocumentor-element-found-in__line">56</span>
 
     </aside>
 
@@ -522,7 +566,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">59</span>
+    <span class="phpdocumentor-element-found-in__line">66</span>
 
     </aside>
 
@@ -530,7 +574,7 @@
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\BitPayKeyUtils\KeyHelper\PrivateKey">PrivateKey</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$ecKey</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$proxy</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\BitPayKeyUtils\KeyHelper\PrivateKey">PrivateKey</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$ecKey</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$proxy</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$platformInfo</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -556,6 +600,13 @@
                 <span class="phpdocumentor-signature__argument__name">$proxy</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
                  = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
+            <dd class="phpdocumentor-argument-list__definition">
+                
+            </dd>
+                    <dt class="phpdocumentor-argument-list__entry">
+                <span class="phpdocumentor-signature__argument__name">$platformInfo</span>
+                : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
+                            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                 
             </dd>
@@ -596,7 +647,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">227</span>
+    <span class="phpdocumentor-element-found-in__line">247</span>
 
     </aside>
 
@@ -675,7 +726,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">168</span>
+    <span class="phpdocumentor-element-found-in__line">184</span>
 
     </aside>
 
@@ -765,7 +816,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">341</span>
+    <span class="phpdocumentor-element-found-in__line">369</span>
 
     </aside>
 
@@ -829,7 +880,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">72</span>
+    <span class="phpdocumentor-element-found-in__line">80</span>
 
     </aside>
 
@@ -879,7 +930,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">108</span>
+    <span class="phpdocumentor-element-found-in__line">120</span>
 
     </aside>
 
@@ -969,7 +1020,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">288</span>
+    <span class="phpdocumentor-element-found-in__line">312</span>
 
     </aside>
 
@@ -1048,7 +1099,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">378</span>
+    <span class="phpdocumentor-element-found-in__line">406</span>
 
     </aside>
 
@@ -1096,7 +1147,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">394</span>
+    <span class="phpdocumentor-element-found-in__line">422</span>
 
     </aside>
 
@@ -1266,6 +1317,7 @@
                                                     <li class=""><a href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_client">$client</a></li>
                                                     <li class=""><a href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_ecKey">$ecKey</a></li>
                                                     <li class=""><a href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_identity">$identity</a></li>
+                                                    <li class=""><a href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_platformInfo">$platformInfo</a></li>
                                                     <li class=""><a href="classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_proxy">$proxy</a></li>
                                             </ul>
                 </li>

--- a/docs/js/searchIndex.js
+++ b/docs/js/searchIndex.js
@@ -9251,6 +9251,11 @@ Search.appendIndex(
             "summary": "",
             "url": "classes/BitPaySDK-PosClient.html#property_env"
         },                {
+            "fqsen": "\\BitPaySDK\\PosClient\u003A\u003A\u0024platformInfo",
+            "name": "platformInfo",
+            "summary": "Value\u0020for\u0020the\u0020X\u002DBitPay\u002DPlatform\u002DInfo\u0020header",
+            "url": "classes/BitPaySDK-PosClient.html#property_platformInfo"
+        },                {
             "fqsen": "\\BitPaySDK\\PosClient\u003A\u003A\u0024token",
             "name": "token",
             "summary": "",
@@ -9390,6 +9395,11 @@ Search.appendIndex(
             "name": "identity",
             "summary": "",
             "url": "classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_identity"
+        },                {
+            "fqsen": "\\BitPaySDK\\Util\\RESTcli\\RESTcli\u003A\u003A\u0024platformInfo",
+            "name": "platformInfo",
+            "summary": "Value\u0020for\u0020the\u0020X\u002DBitPay\u002DPlatform\u002DInfo\u0020header.",
+            "url": "classes/BitPaySDK-Util-RESTcli-RESTcli.html#property_platformInfo"
         },                {
             "fqsen": "\\BitPaySDK\\Util\\RESTcli\\RESTcli\u003A\u003A\u0024proxy",
             "name": "proxy",

--- a/src/BitPaySDK/Client.php
+++ b/src/BitPaySDK/Client.php
@@ -71,6 +71,7 @@ class Client
      * @param string|null      $privateKeySecret Private Key encryption password.
      * @param string|null      $proxy            The url of your proxy to forward requests through. Example:
      *                                           http://********.com:3128
+     * @param string|null      $platformInfo     Value for the X-BitPay-Platform header.
      * @return Client
      * @throws BitPayApiException
      * @throws BitPayGenericException
@@ -80,12 +81,13 @@ class Client
         string $privateKey,
         Tokens $tokens,
         ?string $privateKeySecret = null,
-        ?string $proxy = null
+        ?string $proxy = null,
+        ?string $platformInfo = null,
     ): Client {
         try {
             $key = self::initKeys($privateKey, $privateKeySecret);
 
-            $restCli = new RESTcli($environment, $key, $proxy);
+            $restCli = new RESTcli($environment, $key, $proxy, $platformInfo);
             $tokenCache = $tokens;
 
             return new Client($restCli, $tokenCache);
@@ -99,11 +101,12 @@ class Client
     /**
      * Constructor for use if the keys and SIN are managed by this library.
      *
-     * @param string $configFilePath  The path to the configuration file.
+     * @param string      $configFilePath  The path to the configuration file.
+     * @param string|null $platformInfo    Value for the X-BitPay-Platform header.
      * @return Client
      * @throws BitPayGenericException
      */
-    public static function createWithFile(string $configFilePath): Client
+    public static function createWithFile(string $configFilePath, ?string $platformInfo = null): Client
     {
         try {
             $configData = self::getConfigData($configFilePath);
@@ -113,7 +116,7 @@ class Client
             $key = self::initKeys($config['PrivateKeyPath'], $config['PrivateKeySecret']);
             $proxy = $config['Proxy'] ?? null;
 
-            $restCli = new RESTcli($env, $key, $proxy);
+            $restCli = new RESTcli($env, $key, $proxy, $platformInfo);
             $tokenCache = new Tokens($config['ApiTokens']['merchant'], $config['ApiTokens']['payout']);
 
             return new Client($restCli, $tokenCache);

--- a/src/BitPaySDK/PosClient.php
+++ b/src/BitPaySDK/PosClient.php
@@ -27,22 +27,31 @@ use JsonMapper;
 class PosClient extends Client
 {
     protected string $env;
+
+    /**
+     * Value for the X-BitPay-Platform-Info header
+     * @var string
+     * 
+     */
+    protected string $platformInfo;
     protected Tokens $token;
     protected RESTcli $RESTcli;
 
     /**
      * Constructor for the BitPay SDK to use with the POS facade.
      *
-     * @param $token       string The token generated on the BitPay account.
-     * @param string|null $environment string The target environment [Default: Production].
+     * @param string       $token        The token generated on the BitPay account.
+     * @param string|null  $environment  The target environment [Default: Production].
+     * @param string|null  $platformInfo Value for the X-BitPay-Platform-Info header.
      *
      * @throws BitPayGenericException
      */
-    public function __construct(string $token, string $environment = null)
+    public function __construct(string $token, string $environment = null, ?string $platformInfo = null)
     {
         try {
             $this->token = new Tokens(null, null, $token);
             $this->env = strtolower($environment) === "test" ? Env::TEST : Env::PROD;
+            $this->platformInfo = $platformInfo !== null ? trim($platformInfo) : '';
             $this->init();
             parent::__construct($this->RESTcli, new Tokens(null, null, $token));
         } catch (Exception $e) {
@@ -60,7 +69,7 @@ class PosClient extends Client
     private function init(): void
     {
         try {
-            $this->RESTcli = new RESTcli($this->env, new PrivateKey());
+            $this->RESTcli = new RESTcli($this->env, new PrivateKey(), null, $this->platformInfo);
         } catch (Exception $e) {
             BitPayExceptionProvider::throwGenericExceptionWithMessage(
                 'failed to build configuration : ' . $e->getMessage()
@@ -71,7 +80,7 @@ class PosClient extends Client
     /**
      * Fetch the supported currencies.
      *
-     * @return array     A list of BitPay Invoice objects.
+     * @return array A list of BitPay Invoice objects.
      * @throws BitPayGenericException
      * @throws BitPayApiException
      */

--- a/src/BitPaySDK/PosClient.php
+++ b/src/BitPaySDK/PosClient.php
@@ -31,7 +31,6 @@ class PosClient extends Client
     /**
      * Value for the X-BitPay-Platform-Info header
      * @var string
-     * 
      */
     protected string $platformInfo;
     protected Tokens $token;

--- a/src/BitPaySDK/Util/RESTcli/RESTcli.php
+++ b/src/BitPaySDK/Util/RESTcli/RESTcli.php
@@ -49,7 +49,7 @@ class RESTcli
      * @var string
      */
     protected string $platformInfo;
-    
+
     /**
      * @var string
      */

--- a/src/BitPaySDK/Util/RESTcli/RESTcli.php
+++ b/src/BitPaySDK/Util/RESTcli/RESTcli.php
@@ -45,9 +45,16 @@ class RESTcli
     protected string $identity;
 
     /**
+     * Value for the X-BitPay-Platform-Info header.
+     * @var string
+     */
+    protected string $platformInfo;
+    
+    /**
      * @var string
      */
     protected string $proxy;
+
 
     /**
      * RESTcli constructor.
@@ -56,11 +63,12 @@ class RESTcli
      * @param string|null $proxy
      * @throws BitPayApiException
      */
-    public function __construct(string $environment, PrivateKey $ecKey, ?string $proxy = null)
+    public function __construct(string $environment, PrivateKey $ecKey, ?string $proxy = null, ?string $platformInfo)
     {
         $this->ecKey = $ecKey;
         $this->baseUrl = $environment == Env::TEST ? Env::TEST_URL : Env::PROD_URL;
         $this->proxy = $proxy !== null ? trim($proxy) : '';
+        $this->platformInfo = $platformInfo !== null ? trim($platformInfo) : '';
         $this->init();
     }
 
@@ -87,6 +95,10 @@ class RESTcli
 
             if ($this->proxy !== '') {
                 $config['proxy'] = $this->proxy;
+            }
+
+            if ($this->platformInfo !== '') {
+                $config['defaults']['headers']['x-bitpay-platform-info'] = $this->platformInfo;
             }
 
             $this->client = new GuzzleHttpClient($config);
@@ -126,6 +138,10 @@ class RESTcli
                     BitPayExceptionProvider::throwGenericExceptionWithMessage('Wrong ecKey. ' . $e->getMessage());
                 }
                 $headers['x-identity'] = $this->identity;
+            }
+
+            if ($this->platformInfo !== '') {
+                $headers['x-bitpay-platform-info'] = $this->platformInfo;
             }
 
             $method = "POST";
@@ -190,6 +206,10 @@ class RESTcli
                 $headers['x-identity'] = $this->identity;
             }
 
+            if ($this->platformInfo !== '') {
+                $headers['x-bitpay-platform-info'] = $this->platformInfo;
+            }
+
             $method = 'GET';
 
             LoggerProvider::getLogger()->logRequest($method, $fullURL, null);
@@ -245,6 +265,10 @@ class RESTcli
                 $headers['x-signature'] = $this->ecKey->sign($fullURL);
             } catch (Exception $e) {
                 BitPayExceptionProvider::throwGenericExceptionWithMessage('Wrong ecKey. ' . $e->getMessage());
+            }
+
+            if ($this->platformInfo !== '') {
+                $headers['x-bitpay-platform-info'] = $this->platformInfo;
             }
 
             $method = 'DELETE';
@@ -303,6 +327,10 @@ class RESTcli
                 $headers['x-signature'] = $this->ecKey->sign($fullURL . $jsonRequestData);
             } catch (Exception $e) {
                 BitPayExceptionProvider::throwGenericExceptionWithMessage('Wrong ecKey. ' . $e->getMessage());
+            }
+
+            if ($this->platformInfo !== '') {
+                $headers['x-bitpay-platform-info'] = $this->platformInfo;
             }
 
             $method = 'PUT';

--- a/src/BitPaySDK/Util/RESTcli/RESTcli.php
+++ b/src/BitPaySDK/Util/RESTcli/RESTcli.php
@@ -31,14 +31,17 @@ class RESTcli
      * @var GuzzleHttpClient
      */
     protected GuzzleHttpClient $client;
+
     /**
      * @var string
      */
     protected string $baseUrl;
+
     /**
      * @var PrivateKey
      */
     protected PrivateKey $ecKey;
+
     /**
      * @var string
      */

--- a/test/unit/BitPaySDK/ClientTest.php
+++ b/test/unit/BitPaySDK/ClientTest.php
@@ -110,6 +110,24 @@ class ClientTest extends TestCase
         self::assertInstanceOf(Client::class, $result);
     }
 
+    /**
+     * @throws BitPayApiException
+     */
+    public function testWithDataAndXBitPayPlatformInfoHeader()
+    {
+        $tokens = $this->createMock(Tokens::class);
+        $result = $this->getTestedClassInstance()::createWithData(
+            Env::TEST,
+            __DIR__ . '/bitpay_private_test.key',
+            $tokens,
+            'YourMasterPassword',
+            null,
+            'MyPlatform_v1.0.0'
+        );
+
+        self::assertInstanceOf(Client::class, $result);
+    }
+
     public function testWithDataException()
     {
         $instance = $this->getTestedClassInstance();
@@ -136,12 +154,39 @@ class ClientTest extends TestCase
     }
 
     /**
+     * @throws BitPayApiException
+     */
+    public function testWithFileJsonConfigAndXBitPayPlatformInfoHeader(): Client
+    {
+        $instance = $this->getTestedClassInstance();
+        $result = $instance::createWithFile(
+            __DIR__ . '/BitPay.config-unit.json',
+            'MyPlatform_v1.0.0'
+        );
+        self::assertInstanceOf(Client::class, $result);
+        return $result;
+    }
+
+    /**
      * @throws BitPayGenericException
      */
     public function testWithFileYmlConfig()
     {
         $instance = $this->getTestedClassInstance();
         $result = $instance::createWithFile(__DIR__ . '/BitPay.config-unit.yml');
+        self::assertInstanceOf(Client::class, $result);
+    }
+
+    /**
+     * @throws BitPayGenericException
+     */
+    public function testWithFileYmlConfigAndXBitPayPlatformInfoHeader()
+    {
+        $instance = $this->getTestedClassInstance();
+        $result = $instance::createWithFile(
+            __DIR__ . '/BitPay.config-unit.yml',
+            'MyPlatform_v1.0.0'
+        );
         self::assertInstanceOf(Client::class, $result);
     }
 


### PR DESCRIPTION
# Overview

Similar to the `X-BitPay-Plugin-Info` that looks like this:

```plain
BitPay_PHP_Client_v9.0.4
```

We are now able to use a header called `X-BitPay-Platform-Info` with a value such as this:

```plain
BitPay_Magento2_v9.2.0
```

This will help with debugging because we'll be able to tell both the SDK and plugin versions that are performing requests.
