### PR TITLE
SP-1073 Bump version to 9.1.1

### DIFF
--- a/docs/classes/BitPaySDK-Env.html
+++ b/docs/classes/BitPaySDK-Env.html
@@ -216,7 +216,7 @@
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
     <a class="" href="classes/BitPaySDK-Env.html#constant_BITPAY_PLUGIN_INFO">BITPAY_PLUGIN_INFO</a>
     <span>
-        &nbsp;= &quot;BitPay_PHP_Client_v9.1.0&quot;                            </span>
+        &nbsp;= &quot;BitPay_PHP_Client_v9.1.1&quot;                            </span>
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
@@ -371,7 +371,7 @@
     <span class="phpdocumentor-signature__visibility">public</span>
         <span class="phpdocumentor-signature__type">mixed</span>
     <span class="phpdocumentor-signature__name">BITPAY_PLUGIN_INFO</span>
-    = <span class="phpdocumentor-signature__default-value">&quot;BitPay_PHP_Client_v9.1.0&quot;</span>
+    = <span class="phpdocumentor-signature__default-value">&quot;BitPay_PHP_Client_v9.1.1&quot;</span>
 </code>
 
 

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -10,7 +10,7 @@
     <output>docs</output>
   </paths>
 
-  <version number="9.1.0">
+  <version number="9.1.1">
     <api format="php">
       <source dsn=".">
         <path>src</path>

--- a/src/BitPaySDK/Env.php
+++ b/src/BitPaySDK/Env.php
@@ -17,7 +17,7 @@ interface Env
     public const TEST_URL = "https://test.bitpay.com/";
     public const PROD_URL = "https://bitpay.com/";
     public const BITPAY_API_VERSION = "2.0.0";
-    public const BITPAY_PLUGIN_INFO = "BitPay_PHP_Client_v9.1.0";
+    public const BITPAY_PLUGIN_INFO = "BitPay_PHP_Client_v9.1.1";
     public const BITPAY_API_FRAME = "std";
     public const BITPAY_API_FRAME_VERSION = "1.0.0";
 }


### PR DESCRIPTION
# Overview
This PR bumps the SDK version to 9.1.1 for the documentation and plugin info header.