### PR TITLE
SP-1095 Default $platformInfo to null

### DIFF
--- a/docs/classes/BitPaySDK-Env.html
+++ b/docs/classes/BitPaySDK-Env.html
@@ -216,7 +216,7 @@
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
     <a class="" href="classes/BitPaySDK-Env.html#constant_BITPAY_PLUGIN_INFO">BITPAY_PLUGIN_INFO</a>
     <span>
-        &nbsp;= &quot;BitPay_PHP_Client_v9.1.1&quot;                            </span>
+        &nbsp;= &quot;BitPay_PHP_Client_v9.1.2&quot;                            </span>
 </dt>
 
             <dt class="phpdocumentor-table-of-contents__entry -constant -public">
@@ -371,7 +371,7 @@
     <span class="phpdocumentor-signature__visibility">public</span>
         <span class="phpdocumentor-signature__type">mixed</span>
     <span class="phpdocumentor-signature__name">BITPAY_PLUGIN_INFO</span>
-    = <span class="phpdocumentor-signature__default-value">&quot;BitPay_PHP_Client_v9.1.1&quot;</span>
+    = <span class="phpdocumentor-signature__default-value">&quot;BitPay_PHP_Client_v9.1.2&quot;</span>
 </code>
 
 

--- a/docs/classes/BitPaySDK-Util-RESTcli-RESTcli.html
+++ b/docs/classes/BitPaySDK-Util-RESTcli-RESTcli.html
@@ -647,7 +647,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">250</span>
+    <span class="phpdocumentor-element-found-in__line">254</span>
 
     </aside>
 
@@ -726,7 +726,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">187</span>
+    <span class="phpdocumentor-element-found-in__line">191</span>
 
     </aside>
 
@@ -816,7 +816,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">372</span>
+    <span class="phpdocumentor-element-found-in__line">376</span>
 
     </aside>
 
@@ -880,7 +880,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">83</span>
+    <span class="phpdocumentor-element-found-in__line">87</span>
 
     </aside>
 
@@ -930,7 +930,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">123</span>
+    <span class="phpdocumentor-element-found-in__line">127</span>
 
     </aside>
 
@@ -1020,7 +1020,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">315</span>
+    <span class="phpdocumentor-element-found-in__line">319</span>
 
     </aside>
 
@@ -1099,7 +1099,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">409</span>
+    <span class="phpdocumentor-element-found-in__line">413</span>
 
     </aside>
 
@@ -1147,7 +1147,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/BitPaySDK/Util/RESTcli/RESTcli.php"><a href="files/src-bitpaysdk-util-restcli-restcli.html"><abbr title="src/BitPaySDK/Util/RESTcli/RESTcli.php">RESTcli.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">425</span>
+    <span class="phpdocumentor-element-found-in__line">429</span>
 
     </aside>
 

--- a/docs/classes/BitPaySDK-Util-RESTcli-RESTcli.html
+++ b/docs/classes/BitPaySDK-Util-RESTcli-RESTcli.html
@@ -574,7 +574,7 @@
 
     <code class="phpdocumentor-code phpdocumentor-signature ">
     <span class="phpdocumentor-signature__visibility">public</span>
-                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\BitPayKeyUtils\KeyHelper\PrivateKey">PrivateKey</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$ecKey</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$proxy</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$platformInfo</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
+                    <span class="phpdocumentor-signature__name">__construct</span><span>(</span><span class="phpdocumentor-signature__argument"><span class="phpdocumentor-signature__argument__return-type">string&nbsp;</span><span class="phpdocumentor-signature__argument__name">$environment</span></span><span class="phpdocumentor-signature__argument"><span>, </span><span class="phpdocumentor-signature__argument__return-type"><abbr title="\BitPayKeyUtils\KeyHelper\PrivateKey">PrivateKey</abbr>&nbsp;</span><span class="phpdocumentor-signature__argument__name">$ecKey</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$proxy</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span class="phpdocumentor-signature__argument"><span>[</span><span>, </span><span class="phpdocumentor-signature__argument__return-type">string|null&nbsp;</span><span class="phpdocumentor-signature__argument__name">$platformInfo</span><span> = </span><span class="phpdocumentor-signature__argument__default-value">null</span><span> ]</span></span><span>)</span><span> : </span><span class="phpdocumentor-signature__response_type">mixed</span></code>
 
     <div class="phpdocumentor-label-line">
         </div>
@@ -606,7 +606,7 @@
                     <dt class="phpdocumentor-argument-list__entry">
                 <span class="phpdocumentor-signature__argument__name">$platformInfo</span>
                 : <span class="phpdocumentor-signature__argument__return-type">string|null</span>
-                            </dt>
+                 = <span class="phpdocumentor-signature__argument__default-value">null</span>            </dt>
             <dd class="phpdocumentor-argument-list__definition">
                 
             </dd>

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -10,7 +10,7 @@
     <output>docs</output>
   </paths>
 
-  <version number="9.1.1">
+  <version number="9.1.2">
     <api format="php">
       <source dsn=".">
         <path>src</path>

--- a/src/BitPaySDK/Env.php
+++ b/src/BitPaySDK/Env.php
@@ -17,7 +17,7 @@ interface Env
     public const TEST_URL = "https://test.bitpay.com/";
     public const PROD_URL = "https://bitpay.com/";
     public const BITPAY_API_VERSION = "2.0.0";
-    public const BITPAY_PLUGIN_INFO = "BitPay_PHP_Client_v9.1.1";
+    public const BITPAY_PLUGIN_INFO = "BitPay_PHP_Client_v9.1.2";
     public const BITPAY_API_FRAME = "std";
     public const BITPAY_API_FRAME_VERSION = "1.0.0";
 }

--- a/src/BitPaySDK/Util/RESTcli/RESTcli.php
+++ b/src/BitPaySDK/Util/RESTcli/RESTcli.php
@@ -66,8 +66,12 @@ class RESTcli
      * @param string|null $proxy
      * @throws BitPayApiException
      */
-    public function __construct(string $environment, PrivateKey $ecKey, ?string $proxy = null, ?string $platformInfo = null)
-    {
+    public function __construct(
+        string $environment,
+        PrivateKey $ecKey,
+        ?string $proxy = null,
+        ?string $platformInfo = null
+    ) {
         $this->ecKey = $ecKey;
         $this->baseUrl = $environment == Env::TEST ? Env::TEST_URL : Env::PROD_URL;
         $this->proxy = $proxy !== null ? trim($proxy) : '';

--- a/src/BitPaySDK/Util/RESTcli/RESTcli.php
+++ b/src/BitPaySDK/Util/RESTcli/RESTcli.php
@@ -66,7 +66,7 @@ class RESTcli
      * @param string|null $proxy
      * @throws BitPayApiException
      */
-    public function __construct(string $environment, PrivateKey $ecKey, ?string $proxy = null, ?string $platformInfo)
+    public function __construct(string $environment, PrivateKey $ecKey, ?string $proxy = null, ?string $platformInfo = null)
     {
         $this->ecKey = $ecKey;
         $this->baseUrl = $environment == Env::TEST ? Env::TEST_URL : Env::PROD_URL;


### PR DESCRIPTION
This PR should help with an issue running Magento 2 tests where $platformInfo is nullable but does not default to null, and is ordered after `$proxy` which is nullable and defaults to null.