### PR TITLE
Fix deprecation notice in PosClient constructor

### DIFF
--- a/src/BitPaySDK/PosClient.php
+++ b/src/BitPaySDK/PosClient.php
@@ -45,7 +45,7 @@ class PosClient extends Client
      *
      * @throws BitPayGenericException
      */
-    public function __construct(string $token, string $environment = null, ?string $platformInfo = null)
+    public function __construct(string $token, ?string $environment = null, ?string $platformInfo = null)
     {
         try {
             $this->token = new Tokens(null, null, $token);


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable parameters: a parameter typed `string` but defaulted to `null` is treated as nullable without saying so.

The `$environment` parameter in `PosClient::__construct` relied on this implicit behavior. Declaring it explicitly as `?string` removes the deprecation while keeping the same nullable default.